### PR TITLE
Add NSCopying, NSSecureCoding Support to Informational Classes

### DIFF
--- a/OpenVPN Adapter/OpenVPNAdapter+Public.h
+++ b/OpenVPN Adapter/OpenVPNAdapter+Public.h
@@ -117,22 +117,22 @@ NS_SWIFT_NAME(handle(logMessage:));
  Return information about the most recent connection. Will be available
  after an event of type "OpenVPNAdapterEventConnected, otherwise return nil.
  */
-@property (nullable, readonly, nonatomic) OpenVPNConnectionInfo *connectionInfo;
+@property (nullable, readonly, nonatomic, copy) OpenVPNConnectionInfo *connectionInfo;
 
 /**
  Return current session token or nil if session token is unavailable
  */
-@property (nullable, readonly, nonatomic) OpenVPNSessionToken *sessionToken;
+@property (nullable, readonly, nonatomic, copy) OpenVPNSessionToken *sessionToken;
 
 /**
  Return transport stats
  */
-@property (nonnull, readonly, nonatomic) OpenVPNTransportStats *transportStats;
+@property (nonnull, readonly, nonatomic, copy) OpenVPNTransportStats *transportStats;
 
 /**
  Return tun stats
  */
-@property (nonnull, readonly, nonatomic) OpenVPNInterfaceStats *interfaceStats;
+@property (nonnull, readonly, nonatomic, copy) OpenVPNInterfaceStats *interfaceStats;
 
 /**
  <#Description#>

--- a/OpenVPN Adapter/OpenVPNAdapter+Public.h
+++ b/OpenVPN Adapter/OpenVPNAdapter+Public.h
@@ -117,22 +117,22 @@ NS_SWIFT_NAME(handle(logMessage:));
  Return information about the most recent connection. Will be available
  after an event of type "OpenVPNAdapterEventConnected, otherwise return nil.
  */
-@property (nullable, readonly, nonatomic, copy) OpenVPNConnectionInfo *connectionInfo;
+@property (nullable, readonly, nonatomic) OpenVPNConnectionInfo *connectionInfo;
 
 /**
  Return current session token or nil if session token is unavailable
  */
-@property (nullable, readonly, nonatomic, copy) OpenVPNSessionToken *sessionToken;
+@property (nullable, readonly, nonatomic) OpenVPNSessionToken *sessionToken;
 
 /**
  Return transport stats
  */
-@property (nonnull, readonly, nonatomic, copy) OpenVPNTransportStats *transportStats;
+@property (nonnull, readonly, nonatomic) OpenVPNTransportStats *transportStats;
 
 /**
  Return tun stats
  */
-@property (nonnull, readonly, nonatomic, copy) OpenVPNInterfaceStats *interfaceStats;
+@property (nonnull, readonly, nonatomic) OpenVPNInterfaceStats *interfaceStats;
 
 /**
  <#Description#>

--- a/OpenVPN Adapter/OpenVPNConfiguration.h
+++ b/OpenVPN Adapter/OpenVPNConfiguration.h
@@ -17,7 +17,7 @@
 /**
  Class used to pass configuration
  */
-@interface OpenVPNConfiguration : NSObject
+@interface OpenVPNConfiguration : NSObject <NSCopying, NSSecureCoding>
 
 /**
  OpenVPN profile as a NSData

--- a/OpenVPN Adapter/OpenVPNConfiguration.mm
+++ b/OpenVPN Adapter/OpenVPNConfiguration.mm
@@ -437,4 +437,88 @@ NSString *const OpenVPNTLSCertProfileDefaultValue = @"default";
     _config.clockTickMS = clockTick;
 }
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    OpenVPNConfiguration *configuration = [[OpenVPNConfiguration allocWithZone:zone] init];
+    configuration.fileContent = [self.fileContent copyWithZone:zone];
+    configuration.settings = [self.settings copyWithZone:zone];
+    configuration.guiVersion = [self.guiVersion copyWithZone:zone];
+    configuration.server = [self.server copyWithZone:zone];
+    configuration.proto = self.proto;
+    configuration.ipv6 = self.ipv6;
+    configuration.connectionTimeout = self.connectionTimeout;
+    configuration.tunPersist = self.tunPersist;
+    configuration.googleDNSFallback = self.googleDNSFallback;
+    configuration.autologinSessions = self.autologinSessions;
+    configuration.disableClientCert = self.disableClientCert;
+    configuration.sslDebugLevel = self.sslDebugLevel;
+    configuration.compressionMode = self.compressionMode;
+    configuration.privateKeyPassword = [self.privateKeyPassword copyWithZone:zone];
+    configuration.keyDirection = self.keyDirection;
+    configuration.forceCiphersuitesAESCBC = self.forceCiphersuitesAESCBC;
+    configuration.minTLSVersion = self.minTLSVersion;
+    configuration.tlsCertProfile = self.tlsCertProfile;
+    configuration.peerInfo = [self.peerInfo copyWithZone:zone];
+    configuration.echo = self.echo;
+    configuration.info = self.info;
+    configuration.clockTick = self.clockTick;
+    return configuration;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [aCoder encodeObject:self.fileContent forKey:NSStringFromSelector(@selector(fileContent))];
+    [aCoder encodeObject:self.settings forKey:NSStringFromSelector(@selector(settings))];
+    [aCoder encodeObject:self.guiVersion forKey:NSStringFromSelector(@selector(guiVersion))];
+    [aCoder encodeObject:self.server forKey:NSStringFromSelector(@selector(server))];
+    [aCoder encodeInteger:self.proto forKey:NSStringFromSelector(@selector(proto))];
+    [aCoder encodeInteger:self.ipv6 forKey:NSStringFromSelector(@selector(ipv6))];
+    [aCoder encodeInteger:self.connectionTimeout forKey:NSStringFromSelector(@selector(connectionTimeout))];
+    [aCoder encodeBool:self.tunPersist forKey:NSStringFromSelector(@selector(tunPersist))];
+    [aCoder encodeBool:self.googleDNSFallback forKey:NSStringFromSelector(@selector(googleDNSFallback))];
+    [aCoder encodeBool:self.autologinSessions forKey:NSStringFromSelector(@selector(autologinSessions))];
+    [aCoder encodeBool:self.disableClientCert forKey:NSStringFromSelector(@selector(disableClientCert))];
+    [aCoder encodeInteger:self.sslDebugLevel forKey:NSStringFromSelector(@selector(sslDebugLevel))];
+    [aCoder encodeInteger:self.compressionMode forKey:NSStringFromSelector(@selector(compressionMode))];
+    [aCoder encodeObject:self.privateKeyPassword forKey:NSStringFromSelector(@selector(privateKeyPassword))];
+    [aCoder encodeInteger:self.keyDirection forKey:NSStringFromSelector(@selector(keyDirection))];
+    [aCoder encodeBool:self.forceCiphersuitesAESCBC forKey:NSStringFromSelector(@selector(forceCiphersuitesAESCBC))];
+    [aCoder encodeInteger:self.minTLSVersion forKey:NSStringFromSelector(@selector(minTLSVersion))];
+    [aCoder encodeInteger:self.tlsCertProfile forKey:NSStringFromSelector(@selector(tlsCertProfile))];
+    [aCoder encodeObject:self.peerInfo forKey:NSStringFromSelector(@selector(peerInfo))];
+    [aCoder encodeBool:self.echo forKey:NSStringFromSelector(@selector(echo))];
+    [aCoder encodeBool:self.info forKey:NSStringFromSelector(@selector(info))];
+    [aCoder encodeInteger:self.clockTick forKey:NSStringFromSelector(@selector(clockTick))];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    if ((self = [self init])) {
+        self.fileContent = [aDecoder decodeObjectOfClass:[NSData class] forKey:NSStringFromSelector(@selector(fileContent))];
+        self.settings = [aDecoder decodeObjectOfClass:[NSDictionary class] forKey:NSStringFromSelector(@selector(settings))];
+        self.guiVersion = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(guiVersion))];
+        self.server = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(server))];
+        self.proto = (OpenVPNTransportProtocol)[aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(proto))];
+        self.ipv6 = (OpenVPNIPv6Preference)[aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(ipv6))];
+        self.connectionTimeout = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(connectionTimeout))];
+        self.tunPersist = [aDecoder decodeBoolForKey:NSStringFromSelector(@selector(tunPersist))];
+        self.googleDNSFallback = [aDecoder decodeBoolForKey:NSStringFromSelector(@selector(googleDNSFallback))];
+        self.autologinSessions = [aDecoder decodeBoolForKey:NSStringFromSelector(@selector(autologinSessions))];
+        self.disableClientCert = [aDecoder decodeBoolForKey:NSStringFromSelector(@selector(disableClientCert))];
+        self.sslDebugLevel = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(sslDebugLevel))];
+        self.compressionMode = (OpenVPNCompressionMode)[aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(compressionMode))];
+        self.privateKeyPassword = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(privateKeyPassword))];
+        self.keyDirection = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(keyDirection))];
+        self.forceCiphersuitesAESCBC = [aDecoder decodeBoolForKey:NSStringFromSelector(@selector(forceCiphersuitesAESCBC))];
+        self.minTLSVersion = (OpenVPNMinTLSVersion)[aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(minTLSVersion))];
+        self.tlsCertProfile = (OpenVPNTLSCertProfile)[aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(tlsCertProfile))];
+        self.peerInfo = [aDecoder decodeObjectOfClass:[NSDictionary class] forKey:NSStringFromSelector(@selector(peerInfo))];
+        self.echo = [aDecoder decodeBoolForKey:NSStringFromSelector(@selector(echo))];
+        self.info = [aDecoder decodeBoolForKey:NSStringFromSelector(@selector(info))];
+        self.clockTick = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(clockTick))];
+    }
+    return self;
+}
+
 @end

--- a/OpenVPN Adapter/OpenVPNConnectionInfo.h
+++ b/OpenVPN Adapter/OpenVPNConnectionInfo.h
@@ -11,7 +11,7 @@
 /**
  Class used to provide extra details about successful connection
  */
-@interface OpenVPNConnectionInfo : NSObject
+@interface OpenVPNConnectionInfo : NSObject <NSCopying, NSSecureCoding>
 
 @property (nullable, readonly, nonatomic) NSString *user;
 @property (nullable, readonly, nonatomic) NSString *serverHost;
@@ -24,7 +24,5 @@
 @property (nullable, readonly, nonatomic) NSString *gatewayIPv6;
 @property (nullable, readonly, nonatomic) NSString *clientIP;
 @property (nullable, readonly, nonatomic) NSString *tunName;
-
-- (nonnull instancetype) __unavailable init;
 
 @end

--- a/OpenVPN Adapter/OpenVPNConnectionInfo.mm
+++ b/OpenVPN Adapter/OpenVPNConnectionInfo.mm
@@ -11,25 +11,88 @@
 
 using namespace openvpn;
 
+@interface OpenVPNConnectionInfo ()
+@property (nullable, readwrite, nonatomic) NSString *user;
+@property (nullable, readwrite, nonatomic) NSString *serverHost;
+@property (nullable, readwrite, nonatomic) NSString *serverPort;
+@property (nullable, readwrite, nonatomic) NSString *serverProto;
+@property (nullable, readwrite, nonatomic) NSString *serverIP;
+@property (nullable, readwrite, nonatomic) NSString *vpnIPv4;
+@property (nullable, readwrite, nonatomic) NSString *vpnIPv6;
+@property (nullable, readwrite, nonatomic) NSString *gatewayIPv4;
+@property (nullable, readwrite, nonatomic) NSString *gatewayIPv6;
+@property (nullable, readwrite, nonatomic) NSString *clientIP;
+@property (nullable, readwrite, nonatomic) NSString *tunName;
+@end
+
 @implementation OpenVPNConnectionInfo
 
-- (instancetype)initWithConnectionInfo:(ClientAPI::ConnectionInfo)info
-{
-    self = [super init];
-    if (self) {
-        _user = !info.user.empty() ? [NSString stringWithUTF8String:info.user.c_str()] : nil;
-        _serverHost = !info.serverHost.empty() ? [NSString stringWithUTF8String:info.serverHost.c_str()] : nil;
-        _serverPort = !info.serverPort.empty() ? [NSString stringWithUTF8String:info.serverPort.c_str()] : nil;
-        _serverProto = !info.serverProto.empty() ? [NSString stringWithUTF8String:info.serverProto.c_str()] : nil;
-        _serverIP = !info.serverIp.empty() ? [NSString stringWithUTF8String:info.serverIp.c_str()] : nil;
-        _vpnIPv4 = !info.vpnIp4.empty() ? [NSString stringWithUTF8String:info.vpnIp4.c_str()] : nil;
-        _vpnIPv6 = !info.vpnIp6.empty() ? [NSString stringWithUTF8String:info.vpnIp6.c_str()] : nil;
-        _gatewayIPv4 = !info.gw4.empty() ? [NSString stringWithUTF8String:info.gw4.c_str()] : nil;
-        _gatewayIPv6 = !info.gw6.empty() ? [NSString stringWithUTF8String:info.gw6.c_str()] : nil;
-        _clientIP = !info.clientIp.empty() ? [NSString stringWithUTF8String:info.clientIp.c_str()] : nil;
-        _tunName = !info.tunName.empty() ? [NSString stringWithUTF8String:info.tunName.c_str()] : nil;
+- (instancetype)initWithConnectionInfo:(ClientAPI::ConnectionInfo)info {
+    if ((self = [super init])) {
+        self.user = !info.user.empty() ? [NSString stringWithUTF8String:info.user.c_str()] : nil;
+        self.serverHost = !info.serverHost.empty() ? [NSString stringWithUTF8String:info.serverHost.c_str()] : nil;
+        self.serverPort = !info.serverPort.empty() ? [NSString stringWithUTF8String:info.serverPort.c_str()] : nil;
+        self.serverProto = !info.serverProto.empty() ? [NSString stringWithUTF8String:info.serverProto.c_str()] : nil;
+        self.serverIP = !info.serverIp.empty() ? [NSString stringWithUTF8String:info.serverIp.c_str()] : nil;
+        self.vpnIPv4 = !info.vpnIp4.empty() ? [NSString stringWithUTF8String:info.vpnIp4.c_str()] : nil;
+        self.vpnIPv6 = !info.vpnIp6.empty() ? [NSString stringWithUTF8String:info.vpnIp6.c_str()] : nil;
+        self.gatewayIPv4 = !info.gw4.empty() ? [NSString stringWithUTF8String:info.gw4.c_str()] : nil;
+        self.gatewayIPv6 = !info.gw6.empty() ? [NSString stringWithUTF8String:info.gw6.c_str()] : nil;
+        self.clientIP = !info.clientIp.empty() ? [NSString stringWithUTF8String:info.clientIp.c_str()] : nil;
+        self.tunName = !info.tunName.empty() ? [NSString stringWithUTF8String:info.tunName.c_str()] : nil;
     }
     return self;
+}
+
+- (nonnull id)copyWithZone:(nullable NSZone *)zone {
+    OpenVPNConnectionInfo *info = [[OpenVPNConnectionInfo allocWithZone:zone] init];
+    info.user = [self.user copyWithZone:zone];
+    info.serverHost = [self.serverHost copyWithZone:zone];
+    info.serverPort = [self.serverPort copyWithZone:zone];
+    info.serverProto = [self.serverProto copyWithZone:zone];
+    info.serverIP = [self.serverIP copyWithZone:zone];
+    info.vpnIPv4 = [self.vpnIPv4 copyWithZone:zone];
+    info.vpnIPv6 = [self.vpnIPv6 copyWithZone:zone];
+    info.gatewayIPv4 = [self.gatewayIPv4 copyWithZone:zone];
+    info.gatewayIPv6 = [self.gatewayIPv6 copyWithZone:zone];
+    info.clientIP = [self.clientIP copyWithZone:zone];
+    info.tunName = [self.tunName copyWithZone:zone];
+    return info;
+}
+
+- (void)encodeWithCoder:(nonnull NSCoder *)aCoder {
+    [aCoder encodeObject:self.user forKey:NSStringFromSelector(@selector(user))];
+    [aCoder encodeObject:self.serverHost forKey:NSStringFromSelector(@selector(serverHost))];
+    [aCoder encodeObject:self.serverPort forKey:NSStringFromSelector(@selector(serverPort))];
+    [aCoder encodeObject:self.serverProto forKey:NSStringFromSelector(@selector(serverProto))];
+    [aCoder encodeObject:self.serverIP forKey:NSStringFromSelector(@selector(serverIP))];
+    [aCoder encodeObject:self.vpnIPv4 forKey:NSStringFromSelector(@selector(vpnIPv4))];
+    [aCoder encodeObject:self.vpnIPv6 forKey:NSStringFromSelector(@selector(vpnIPv6))];
+    [aCoder encodeObject:self.gatewayIPv4 forKey:NSStringFromSelector(@selector(gatewayIPv4))];
+    [aCoder encodeObject:self.gatewayIPv6 forKey:NSStringFromSelector(@selector(gatewayIPv6))];
+    [aCoder encodeObject:self.clientIP forKey:NSStringFromSelector(@selector(clientIP))];
+    [aCoder encodeObject:self.tunName forKey:NSStringFromSelector(@selector(tunName))];
+}
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder {
+    if ((self = [self init])) {
+        self.user = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(user))];
+        self.serverHost = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(serverHost))];
+        self.serverPort = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(serverPort))];
+        self.serverProto = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(serverProto))];
+        self.serverIP = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(serverIP))];
+        self.vpnIPv4 = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(vpnIPv4))];
+        self.vpnIPv6 = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(vpnIPv6))];
+        self.gatewayIPv4 = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(gatewayIPv4))];
+        self.gatewayIPv6 = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(gatewayIPv6))];
+        self.clientIP = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(clientIP))];
+        self.tunName = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(tunName))];
+    }
+    return self;
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
 }
 
 @end

--- a/OpenVPN Adapter/OpenVPNInterfaceStats.h
+++ b/OpenVPN Adapter/OpenVPNInterfaceStats.h
@@ -11,7 +11,7 @@
 /**
  Class used to provide stats for an interface
  */
-@interface OpenVPNInterfaceStats : NSObject
+@interface OpenVPNInterfaceStats : NSObject <NSCopying, NSSecureCoding>
 
 /**
  Amount of received bytes
@@ -19,7 +19,7 @@
 @property (readonly, nonatomic) NSInteger bytesIn;
 
 /**
- Amout of sent bytes
+ Amount of sent bytes
  */
 @property (readonly, nonatomic) NSInteger bytesOut;
 
@@ -29,7 +29,7 @@
 @property (readonly, nonatomic) NSInteger packetsIn;
 
 /**
- Amout of sent packets
+ Amount of sent packets
  */
 @property (readonly, nonatomic) NSInteger packetsOut;
 
@@ -42,7 +42,5 @@
  Amount of outgoing packets handling errors
  */
 @property (readonly, nonatomic) NSInteger errorsOut;
-
-- (nonnull instancetype) __unavailable init;
 
 @end

--- a/OpenVPN Adapter/OpenVPNInterfaceStats.h
+++ b/OpenVPN Adapter/OpenVPNInterfaceStats.h
@@ -19,7 +19,7 @@
 @property (readonly, nonatomic) NSInteger bytesIn;
 
 /**
- Amount of sent bytes
+ Amout of sent bytes
  */
 @property (readonly, nonatomic) NSInteger bytesOut;
 
@@ -29,7 +29,7 @@
 @property (readonly, nonatomic) NSInteger packetsIn;
 
 /**
- Amount of sent packets
+ Amout of sent packets
  */
 @property (readonly, nonatomic) NSInteger packetsOut;
 

--- a/OpenVPN Adapter/OpenVPNInterfaceStats.mm
+++ b/OpenVPN Adapter/OpenVPNInterfaceStats.mm
@@ -9,19 +9,63 @@
 #import "OpenVPNInterfaceStats.h"
 #import "OpenVPNInterfaceStats+Internal.h"
 
+@interface OpenVPNInterfaceStats ()
+@property (readwrite, nonatomic) NSInteger bytesIn;
+@property (readwrite, nonatomic) NSInteger bytesOut;
+@property (readwrite, nonatomic) NSInteger packetsIn;
+@property (readwrite, nonatomic) NSInteger packetsOut;
+@property (readwrite, nonatomic) NSInteger errorsIn;
+@property (readwrite, nonatomic) NSInteger errorsOut;
+@end
+
 @implementation OpenVPNInterfaceStats
 
 - (instancetype)initWithInterfaceStats:(ClientAPI::InterfaceStats)stats {
-    self = [super init];
-    if (self) {
-        _bytesIn = stats.bytesIn;
-        _bytesOut = stats.bytesOut;
-        _packetsIn = stats.packetsIn;
-        _packetsOut = stats.packetsOut;
-        _errorsIn = stats.errorsIn;
-        _errorsOut = stats.errorsOut;
+    if ((self = [super init])) {
+        self.bytesIn = stats.bytesIn;
+        self.bytesOut = stats.bytesOut;
+        self.packetsIn = stats.packetsIn;
+        self.packetsOut = stats.packetsOut;
+        self.errorsIn = stats.errorsIn;
+        self.errorsOut = stats.errorsOut;
     }
     return self;
+}
+
+- (nonnull id)copyWithZone:(nullable NSZone *)zone {
+    OpenVPNInterfaceStats *stats = [[OpenVPNInterfaceStats allocWithZone:zone] init];
+    stats.bytesIn = self.bytesIn;
+    stats.bytesOut = self.bytesOut;
+    stats.packetsIn = self.packetsIn;
+    stats.packetsOut = self.packetsOut;
+    stats.errorsIn = self.errorsIn;
+    stats.errorsOut = self.errorsOut;
+    return stats;
+}
+
+- (void)encodeWithCoder:(nonnull NSCoder *)aCoder {
+    [aCoder encodeInteger:self.bytesIn forKey:NSStringFromSelector(@selector(bytesIn))];
+    [aCoder encodeInteger:self.bytesOut forKey:NSStringFromSelector(@selector(bytesOut))];
+    [aCoder encodeInteger:self.packetsIn forKey:NSStringFromSelector(@selector(packetsIn))];
+    [aCoder encodeInteger:self.packetsOut forKey:NSStringFromSelector(@selector(packetsOut))];
+    [aCoder encodeInteger:self.errorsIn forKey:NSStringFromSelector(@selector(errorsIn))];
+    [aCoder encodeInteger:self.errorsOut forKey:NSStringFromSelector(@selector(errorsOut))];
+}
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder {
+    if ((self = [self init])) {
+        self.bytesIn = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(bytesIn))];
+        self.bytesOut = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(bytesOut))];
+        self.packetsIn = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(packetsIn))];
+        self.packetsOut = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(packetsOut))];
+        self.errorsIn = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(errorsIn))];
+        self.errorsOut = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(errorsOut))];
+    }
+    return self;
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
 }
 
 @end

--- a/OpenVPN Adapter/OpenVPNSessionToken.h
+++ b/OpenVPN Adapter/OpenVPNSessionToken.h
@@ -11,7 +11,7 @@
 /**
  Class used to get session token from VPN core
  */
-@interface OpenVPNSessionToken : NSObject
+@interface OpenVPNSessionToken : NSObject <NSCopying, NSSecureCoding>
 
 @property (nullable, readonly, nonatomic) NSString *username;
 
@@ -19,7 +19,5 @@
  An OpenVPN Session ID, used as a proxy for password
  */
 @property (nullable, readonly, nonatomic) NSString *session;
-
-- (nonnull instancetype) __unavailable init;
 
 @end

--- a/OpenVPN Adapter/OpenVPNSessionToken.mm
+++ b/OpenVPN Adapter/OpenVPNSessionToken.mm
@@ -10,15 +10,43 @@
 
 using namespace openvpn;
 
+@interface OpenVPNSessionToken ()
+@property (nullable, readwrite, nonatomic) NSString *username;
+@property (nullable, readwrite, nonatomic) NSString *session;
+@end
+
 @implementation OpenVPNSessionToken
 
 - (instancetype)initWithSessionToken:(ClientAPI::SessionToken)token {
-    self = [super init];
-    if (self) {
-        _username = !token.username.empty() ? [NSString stringWithUTF8String:token.username.c_str()] : nil;
-        _session = !token.session_id.empty() ? [NSString stringWithUTF8String:token.session_id.c_str()] : nil;
+    if ((self = [super init])) {
+        self.username = !token.username.empty() ? [NSString stringWithUTF8String:token.username.c_str()] : nil;
+        self.session = !token.session_id.empty() ? [NSString stringWithUTF8String:token.session_id.c_str()] : nil;
     }
     return self;
+}
+
+- (nonnull id)copyWithZone:(nullable NSZone *)zone {
+    OpenVPNSessionToken *token = [[OpenVPNSessionToken allocWithZone:zone] init];
+    token.username = [self.username copyWithZone:zone];
+    token.session = [self.session copyWithZone:zone];
+    return token;
+}
+
+- (void)encodeWithCoder:(nonnull NSCoder *)aCoder {
+    [aCoder encodeObject:self.username forKey:NSStringFromSelector(@selector(username))];
+    [aCoder encodeObject:self.session forKey:NSStringFromSelector(@selector(session))];
+}
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder {
+    if ((self = [self init])) {
+        self.username = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(username))];
+        self.session = [aDecoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(session))];
+    }
+    return self;
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
 }
 
 @end

--- a/OpenVPN Adapter/OpenVPNTransportStats.h
+++ b/OpenVPN Adapter/OpenVPNTransportStats.h
@@ -11,7 +11,7 @@
 /**
  Class used to provide basic transport stats
  */
-@interface OpenVPNTransportStats : NSObject
+@interface OpenVPNTransportStats : NSObject <NSCopying, NSSecureCoding>
 
 /**
  Amount of received bytes
@@ -34,11 +34,8 @@
 @property (readonly, nonatomic) NSInteger packetsOut;
 
 /**
- Number of binary milliseconds (1/1024th of a second) since
- last packet was received, or -1 if undefined
+ Date when last packet was received, or nil if undefined
  */
-@property (readonly, nonatomic) NSInteger lastPacketReceived;
-
-- (nonnull instancetype) __unavailable init;
+@property (readonly, nonatomic, nullable) NSDate *lastPacketReceived;
 
 @end

--- a/OpenVPN Adapter/OpenVPNTransportStats.h
+++ b/OpenVPN Adapter/OpenVPNTransportStats.h
@@ -34,8 +34,9 @@
 @property (readonly, nonatomic) NSInteger packetsOut;
 
 /**
- Date when last packet was received, or nil if undefined
+ Number of binary milliseconds (1/1024th of a second) since
+ last packet was received, or -1 if undefined
  */
-@property (readonly, nonatomic, nullable) NSDate *lastPacketReceived;
+@property (readonly, nonatomic) NSInteger lastPacketReceived;
 
 @end

--- a/OpenVPN Adapter/OpenVPNTransportStats.mm
+++ b/OpenVPN Adapter/OpenVPNTransportStats.mm
@@ -10,19 +10,58 @@
 
 using namespace openvpn;
 
+@interface OpenVPNTransportStats ()
+@property (readwrite, nonatomic) NSInteger bytesIn;
+@property (readwrite, nonatomic) NSInteger bytesOut;
+@property (readwrite, nonatomic) NSInteger packetsIn;
+@property (readwrite, nonatomic) NSInteger packetsOut;
+@property (readwrite, nonatomic) NSDate *lastPacketReceived;
+@end
+
 @implementation OpenVPNTransportStats
 
-- (instancetype)initWithTransportStats:(ClientAPI::TransportStats)stats
-{
-    self = [super init];
-    if (self) {
-        _bytesIn = stats.bytesIn;
-        _bytesOut = stats.bytesOut;
-        _packetsIn = stats.packetsIn;
-        _packetsOut = stats.packetsOut;
-        _lastPacketReceived = stats.lastPacketReceived;
+- (instancetype)initWithTransportStats:(ClientAPI::TransportStats)stats {
+    if ((self = [self init])) {
+        self.bytesIn = stats.bytesIn;
+        self.bytesOut = stats.bytesOut;
+        self.packetsIn = stats.packetsIn;
+        self.packetsOut = stats.packetsOut;
+        self.lastPacketReceived = stats.lastPacketReceived >= 0 ? [NSDate dateWithTimeIntervalSinceNow:stats.lastPacketReceived / -1024.0] : nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    OpenVPNTransportStats *statistics = [[OpenVPNTransportStats allocWithZone:zone] init];
+    statistics.bytesIn = self.bytesIn;
+    statistics.bytesOut = self.bytesOut;
+    statistics.packetsIn = self.packetsIn;
+    statistics.packetsOut = self.packetsOut;
+    statistics.lastPacketReceived = [self.lastPacketReceived copyWithZone:zone];
+    return statistics;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [aCoder encodeInteger:self.bytesIn forKey:NSStringFromSelector(@selector(bytesIn))];
+    [aCoder encodeInteger:self.bytesOut forKey:NSStringFromSelector(@selector(bytesOut))];
+    [aCoder encodeInteger:self.packetsIn forKey:NSStringFromSelector(@selector(packetsIn))];
+    [aCoder encodeInteger:self.packetsOut forKey:NSStringFromSelector(@selector(packetsOut))];
+    [aCoder encodeObject:self.lastPacketReceived forKey:NSStringFromSelector(@selector(lastPacketReceived))];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    if ((self = [super init])) {
+        self.bytesIn = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(bytesIn))];
+        self.bytesOut = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(bytesOut))];
+        self.packetsIn = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(packetsIn))];
+        self.packetsOut = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(packetsOut))];
+        self.lastPacketReceived = [aDecoder decodeObjectOfClass:[NSDate class] forKey:NSStringFromSelector(@selector(lastPacketReceived))];
+    }
+    return self;
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
 }
 
 @end

--- a/OpenVPN Adapter/OpenVPNTransportStats.mm
+++ b/OpenVPN Adapter/OpenVPNTransportStats.mm
@@ -15,7 +15,7 @@ using namespace openvpn;
 @property (readwrite, nonatomic) NSInteger bytesOut;
 @property (readwrite, nonatomic) NSInteger packetsIn;
 @property (readwrite, nonatomic) NSInteger packetsOut;
-@property (readwrite, nonatomic) NSDate *lastPacketReceived;
+@property (readwrite, nonatomic) NSInteger lastPacketReceived;
 @end
 
 @implementation OpenVPNTransportStats
@@ -26,7 +26,7 @@ using namespace openvpn;
         self.bytesOut = stats.bytesOut;
         self.packetsIn = stats.packetsIn;
         self.packetsOut = stats.packetsOut;
-        self.lastPacketReceived = stats.lastPacketReceived >= 0 ? [NSDate dateWithTimeIntervalSinceNow:stats.lastPacketReceived / -1024.0] : nil;
+        self.lastPacketReceived = stats.lastPacketReceived;
     }
     return self;
 }
@@ -37,7 +37,7 @@ using namespace openvpn;
     statistics.bytesOut = self.bytesOut;
     statistics.packetsIn = self.packetsIn;
     statistics.packetsOut = self.packetsOut;
-    statistics.lastPacketReceived = [self.lastPacketReceived copyWithZone:zone];
+    statistics.lastPacketReceived = self.lastPacketReceived;
     return statistics;
 }
 
@@ -46,7 +46,7 @@ using namespace openvpn;
     [aCoder encodeInteger:self.bytesOut forKey:NSStringFromSelector(@selector(bytesOut))];
     [aCoder encodeInteger:self.packetsIn forKey:NSStringFromSelector(@selector(packetsIn))];
     [aCoder encodeInteger:self.packetsOut forKey:NSStringFromSelector(@selector(packetsOut))];
-    [aCoder encodeObject:self.lastPacketReceived forKey:NSStringFromSelector(@selector(lastPacketReceived))];
+    [aCoder encodeInteger:self.lastPacketReceived forKey:NSStringFromSelector(@selector(lastPacketReceived))];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
@@ -55,7 +55,7 @@ using namespace openvpn;
         self.bytesOut = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(bytesOut))];
         self.packetsIn = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(packetsIn))];
         self.packetsOut = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(packetsOut))];
-        self.lastPacketReceived = [aDecoder decodeObjectOfClass:[NSDate class] forKey:NSStringFromSelector(@selector(lastPacketReceived))];
+        self.lastPacketReceived = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(lastPacketReceived))];
     }
     return self;
 }


### PR DESCRIPTION
It is possible for a NEPacketTunnelProvider and it's containing app to communicate with each other through the `func sendProviderMessage(_ messageData: Data, responseHandler: ((Data?) -> Swift.Void)? = nil) throws` method on `NETunnelProviderSession`.

This allows the app to request information relating to the current VPN connection. The response is encoded as a (NS)Data object. Currently the `OpenVPNConnectionInfo`, `OpenVPNInterfaceStats`, `OpenVPNSessionToken`, and `OpenVPNTransportStats` vended by `OpenVPNAdapter` are not `NSSecureCoding` compliant, therefore some custom encoding strategy must be used in order to convert these objects to data objects, and back again.

I propose making the above mentioned classes conformant to `NSSecureCoding`, and whilst we're at it, `NSCopying` compliant to.

This pull request also modifies the `lastPacketReceived` property on `OpenVPNTransportStats`, changing it from a time interval in binary milliseconds, which is unusual in Objective-C and Swift, and instead representing this as a (NS)Date object, which is more in tune with iOS/macOS development.