### PR TITLE
Reconnection Bugfix Proposal

### DIFF
--- a/OpenVPN Adapter/OpenVPNAdapter+Internal.h
+++ b/OpenVPN Adapter/OpenVPNAdapter+Internal.h
@@ -30,6 +30,7 @@ using namespace openvpn;
 - (BOOL)setMTU:(NSNumber *)mtu;
 
 - (NSInteger)establishTunnel;
+- (void)teardownTunnel:(BOOL)disconnect;
 
 - (void)handleEvent:(const ClientAPI::Event *)event;
 - (void)handleLog:(const ClientAPI::LogInfo *)log;

--- a/OpenVPN Adapter/OpenVPNAdapter.mm
+++ b/OpenVPN Adapter/OpenVPNAdapter.mm
@@ -325,14 +325,16 @@ static void socketCallback(CFSocketRef socket, CFSocketCallBackType type, CFData
         return -1;
     }
     
-    [self resetTunnelSettings];
-    
     if (self.packetFlow) {
         [self readTUNPackets];
         return CFSocketGetNative(self.tunSocket);
     } else {
         return -1;
     }
+}
+
+- (void)teardownTunnel:(BOOL)disconnect {
+    [self resetTunnelSettings];
 }
 
 - (void)resetTunnelSettings {
@@ -510,8 +512,6 @@ static void socketCallback(CFSocketRef socket, CFSocketCallBackType type, CFData
                 [self.delegate handleError:error];
             }];
         }
-        
-        [self resetTunnelSettings];
         
         if (self.vpnSocket) {
             CFSocketInvalidate(self.vpnSocket);

--- a/OpenVPN Adapter/OpenVPNAdapter.mm
+++ b/OpenVPN Adapter/OpenVPNAdapter.mm
@@ -38,8 +38,8 @@
 
 @property (assign, nonatomic) OpenVPNClient *vpnClient;
 
-@property CFSocketRef vpnSocket;
-@property CFSocketRef tunSocket;
+@property (assign, nonatomic) CFSocketRef vpnSocket;
+@property (assign, nonatomic) CFSocketRef tunSocket;
 
 @property (strong, nonatomic) NSString *remoteAddress;
 
@@ -335,6 +335,18 @@ static void socketCallback(CFSocketRef socket, CFSocketCallBackType type, CFData
 
 - (void)teardownTunnel:(BOOL)disconnect {
     [self resetTunnelSettings];
+    
+    if (self.vpnSocket) {
+        CFSocketInvalidate(self.vpnSocket);
+        CFRelease(self.vpnSocket);
+        self.vpnSocket = nil;
+    }
+    
+    if (self.tunSocket) {
+        CFSocketInvalidate(self.tunSocket);
+        CFRelease(self.tunSocket);
+        self.tunSocket = nil;
+    }
 }
 
 - (void)resetTunnelSettings {
@@ -513,16 +525,6 @@ static void socketCallback(CFSocketRef socket, CFSocketCallBackType type, CFData
             }];
         }
         
-        if (self.vpnSocket) {
-            CFSocketInvalidate(self.vpnSocket);
-            CFRelease(self.vpnSocket);
-        }
-        
-        if (self.tunSocket) {
-            CFSocketInvalidate(self.tunSocket);
-            CFRelease(self.tunSocket);
-        }
-        
         OpenVPNClient::uninit_process();
     });
 }
@@ -570,7 +572,12 @@ static void socketCallback(CFSocketRef socket, CFSocketCallBackType type, CFData
 }
 
 - (void)writeVPNPackets:(NSArray<NSData *> *)packets protocols:(NSArray<NSNumber *> *)protocols {
-    [packets enumerateObjectsUsingBlock:^(NSData * data, NSUInteger idx, BOOL * stop) {
+    [packets enumerateObjectsUsingBlock:^(NSData *data, NSUInteger idx, BOOL *stop) {
+        if (!self.vpnSocket) {
+            *stop = YES;
+            return;
+        }
+        
         // Prepare data for sending
         NSData *packet = [self prepareVPNPacket:data protocol:protocols[idx]];
         

--- a/OpenVPN Adapter/OpenVPNAdapter.mm
+++ b/OpenVPN Adapter/OpenVPNAdapter.mm
@@ -325,12 +325,24 @@ static void socketCallback(CFSocketRef socket, CFSocketCallBackType type, CFData
         return -1;
     }
     
+    [self resetTunnelSettings];
+    
     if (self.packetFlow) {
         [self readTUNPackets];
         return CFSocketGetNative(self.tunSocket);
     } else {
         return -1;
     }
+}
+
+- (void)resetTunnelSettings {
+    self.remoteAddress = nil;
+    self.defaultGatewayIPv6 = nil;
+    self.defaultGatewayIPv4 = nil;
+    self.tunnelSettingsIPv6 = [[OpenVPNTunnelSettings alloc] init];
+    self.tunnelSettingsIPv4 = [[OpenVPNTunnelSettings alloc] init];
+    self.searchDomains = [[NSMutableArray alloc] init];
+    self.mtu = nil;
 }
 
 #pragma mark Event and Log Handlers
@@ -499,14 +511,7 @@ static void socketCallback(CFSocketRef socket, CFSocketCallBackType type, CFData
             }];
         }
         
-        self.remoteAddress = nil;
-        
-        self.tunnelSettingsIPv6 = nil;
-        self.tunnelSettingsIPv4 = nil;
-        
-        self.searchDomains = nil;
-        
-        self.mtu = nil;
+        [self resetTunnelSettings];
         
         if (self.vpnSocket) {
             CFSocketInvalidate(self.vpnSocket);

--- a/OpenVPN Adapter/OpenVPNClient.mm
+++ b/OpenVPN Adapter/OpenVPNClient.mm
@@ -93,7 +93,9 @@ bool OpenVPNClient::tun_builder_persist() {
 
 void OpenVPNClient::tun_builder_establish_lite() { }
 
-void OpenVPNClient::tun_builder_teardown(bool disconnect) { }
+void OpenVPNClient::tun_builder_teardown(bool disconnect) {
+    [(__bridge OpenVPNAdapter *)adapter teardownTunnel:disconnect];
+}
 
 bool OpenVPNClient::socket_protect(int socket) {
     return true;


### PR DESCRIPTION
We are currently experiencing an issue where the OpenVPN Adapter fails to establish a reliable connection once a reconnect has occurred. A reconnect may occur due to server connection problems, or more likely due to an interface change such as a device transitioning from WiFi to cellular.

The steps to recreate the issue are as follows: 

1. Use the framework to connect to a VPN server whilst the device is on WiFi. The device will connect normally.
2. Turn off WiFi. The device will reconnect to the VPN server, but the device appears to have poor/no connectivity.

After some investigation, we found that as each reconnect occurs, the IPv4 and IPv6 addresses including DNS are duplicated, in other words the array holding these values continues to grow without being emptied first.

It is clear that the developer @ss-abramchuk was aware of this possible issue so the relevant objects are [nilled out](https://github.com/ss-abramchuk/OpenVPNAdapter/blob/master/OpenVPN%20Adapter/OpenVPNAdapter.mm#L502-L509) at the end of a connection period.
However, if a device reconnects, then it hasn't yet disconnected, and so this nilling out does not occur and the duplication arises.

This PR proposes adding a nilling out step after the tunnel is established, as well as after a connection ceases.

I welcome additional discussion if this fix follows the wrong approach, if it doesn't go far enough, or there is a better solution to be had.