### PR TITLE
OpeVPNTransportStats lastPacketReceived NSInteger -> NSDate

### DIFF
--- a/OpenVPN Adapter/OpenVPNTransportStats.h
+++ b/OpenVPN Adapter/OpenVPNTransportStats.h
@@ -34,9 +34,8 @@
 @property (readonly, nonatomic) NSInteger packetsOut;
 
 /**
- Number of binary milliseconds (1/1024th of a second) since
- last packet was received, or -1 if undefined
+ Date when last packet was received, or nil if undefined
  */
-@property (readonly, nonatomic) NSInteger lastPacketReceived;
+@property (readonly, nonatomic, nullable) NSDate *lastPacketReceived;
 
 @end

--- a/OpenVPN Adapter/OpenVPNTransportStats.h
+++ b/OpenVPN Adapter/OpenVPNTransportStats.h
@@ -34,8 +34,9 @@
 @property (readonly, nonatomic) NSInteger packetsOut;
 
 /**
- Date when last packet was received, or nil if undefined
+ Number of binary milliseconds (1/1024th of a second) since
+ last packet was received, or -1 if undefined
  */
-@property (readonly, nonatomic, nullable) NSDate *lastPacketReceived;
+@property (readonly, nonatomic) NSInteger lastPacketReceived;
 
 @end

--- a/OpenVPN Adapter/OpenVPNTransportStats.mm
+++ b/OpenVPN Adapter/OpenVPNTransportStats.mm
@@ -15,7 +15,7 @@ using namespace openvpn;
 @property (readwrite, nonatomic) NSInteger bytesOut;
 @property (readwrite, nonatomic) NSInteger packetsIn;
 @property (readwrite, nonatomic) NSInteger packetsOut;
-@property (readwrite, nonatomic) NSDate *lastPacketReceived;
+@property (readwrite, nonatomic) NSInteger lastPacketReceived;
 @end
 
 @implementation OpenVPNTransportStats
@@ -26,7 +26,7 @@ using namespace openvpn;
         self.bytesOut = stats.bytesOut;
         self.packetsIn = stats.packetsIn;
         self.packetsOut = stats.packetsOut;
-        self.lastPacketReceived = stats.lastPacketReceived >= 0 ? [NSDate dateWithTimeIntervalSinceNow:stats.lastPacketReceived / -1024.0] : nil;
+        self.lastPacketReceived = stats.lastPacketReceived;
     }
     return self;
 }
@@ -37,7 +37,7 @@ using namespace openvpn;
     statistics.bytesOut = self.bytesOut;
     statistics.packetsIn = self.packetsIn;
     statistics.packetsOut = self.packetsOut;
-    statistics.lastPacketReceived = [self.lastPacketReceived copyWithZone:zone];
+    statistics.lastPacketReceived = self.lastPacketReceived;
     return statistics;
 }
 
@@ -46,7 +46,7 @@ using namespace openvpn;
     [aCoder encodeInteger:self.bytesOut forKey:NSStringFromSelector(@selector(bytesOut))];
     [aCoder encodeInteger:self.packetsIn forKey:NSStringFromSelector(@selector(packetsIn))];
     [aCoder encodeInteger:self.packetsOut forKey:NSStringFromSelector(@selector(packetsOut))];
-    [aCoder encodeObject:self.lastPacketReceived forKey:NSStringFromSelector(@selector(lastPacketReceived))];
+    [aCoder encodeInteger:self.lastPacketReceived forKey:NSStringFromSelector(@selector(lastPacketReceived))];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
@@ -55,7 +55,7 @@ using namespace openvpn;
         self.bytesOut = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(bytesOut))];
         self.packetsIn = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(packetsIn))];
         self.packetsOut = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(packetsOut))];
-        self.lastPacketReceived = [aDecoder decodeObjectOfClass:[NSDate class] forKey:NSStringFromSelector(@selector(lastPacketReceived))];
+        self.lastPacketReceived = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(lastPacketReceived))];
     }
     return self;
 }

--- a/OpenVPN Adapter/OpenVPNTransportStats.mm
+++ b/OpenVPN Adapter/OpenVPNTransportStats.mm
@@ -15,7 +15,7 @@ using namespace openvpn;
 @property (readwrite, nonatomic) NSInteger bytesOut;
 @property (readwrite, nonatomic) NSInteger packetsIn;
 @property (readwrite, nonatomic) NSInteger packetsOut;
-@property (readwrite, nonatomic) NSInteger lastPacketReceived;
+@property (readwrite, nonatomic) NSDate *lastPacketReceived;
 @end
 
 @implementation OpenVPNTransportStats
@@ -26,7 +26,7 @@ using namespace openvpn;
         self.bytesOut = stats.bytesOut;
         self.packetsIn = stats.packetsIn;
         self.packetsOut = stats.packetsOut;
-        self.lastPacketReceived = stats.lastPacketReceived;
+        self.lastPacketReceived = stats.lastPacketReceived >= 0 ? [NSDate dateWithTimeIntervalSinceNow:stats.lastPacketReceived / -1024.0] : nil;
     }
     return self;
 }
@@ -37,7 +37,7 @@ using namespace openvpn;
     statistics.bytesOut = self.bytesOut;
     statistics.packetsIn = self.packetsIn;
     statistics.packetsOut = self.packetsOut;
-    statistics.lastPacketReceived = self.lastPacketReceived;
+    statistics.lastPacketReceived = [self.lastPacketReceived copyWithZone:zone];
     return statistics;
 }
 
@@ -46,7 +46,7 @@ using namespace openvpn;
     [aCoder encodeInteger:self.bytesOut forKey:NSStringFromSelector(@selector(bytesOut))];
     [aCoder encodeInteger:self.packetsIn forKey:NSStringFromSelector(@selector(packetsIn))];
     [aCoder encodeInteger:self.packetsOut forKey:NSStringFromSelector(@selector(packetsOut))];
-    [aCoder encodeInteger:self.lastPacketReceived forKey:NSStringFromSelector(@selector(lastPacketReceived))];
+    [aCoder encodeObject:self.lastPacketReceived forKey:NSStringFromSelector(@selector(lastPacketReceived))];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
@@ -55,7 +55,7 @@ using namespace openvpn;
         self.bytesOut = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(bytesOut))];
         self.packetsIn = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(packetsIn))];
         self.packetsOut = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(packetsOut))];
-        self.lastPacketReceived = [aDecoder decodeIntegerForKey:NSStringFromSelector(@selector(lastPacketReceived))];
+        self.lastPacketReceived = [aDecoder decodeObjectOfClass:[NSDate class] forKey:NSStringFromSelector(@selector(lastPacketReceived))];
     }
     return self;
 }


### PR DESCRIPTION
This pull request modifies the ‘lastPacketReceived’ property on ‘OpenVPNTransportStats’, changing it from a time interval in binary milliseconds, which is unusual in Objective-C and Swift, and instead representing this as a (NS)Date object, which is more in tune with iOS/macOS development.