### PR TITLE
Convert OpenVPNAdapterError to NS_ERROR_ENUM

### DIFF
--- a/OpenVPN Adapter/OpenVPNError.h
+++ b/OpenVPN Adapter/OpenVPNError.h
@@ -17,7 +17,7 @@ FOUNDATION_EXPORT NSString * __nonnull const OpenVPNAdapterErrorMessageKey;
 /**
  OpenVPN error codes
  */
-typedef NS_ENUM(NSInteger, OpenVPNAdapterError) {
+typedef NS_ERROR_ENUM(OpenVPNAdapterErrorDomain, OpenVPNAdapterError) {
     OpenVPNAdapterErrorConfigurationFailure = 1,
     OpenVPNAdapterErrorCredentialsFailure,
     OpenVPNAdapterErrorNetworkRecvError,


### PR DESCRIPTION
This is a minor change which adds enhanced compatibility when using the Swift Programming Language.

When interacting with OpenVPNAdapterError in Swift currently, you have to write code like this:

```swift
throw NSError(domain: OpenVPNAdapterErrorDomain, code: OpenVPNAdapterError.configurationFailure.rawValue, userInfo: nil)
```

However when interacting errors defined as `NS_ERROR_ENUM`, the experience is far more swifty:

```swift
throw OpenVPNAdapterError(.configurationFailure)
```