### PR TITLE
Update NS Annotations

### DIFF
--- a/OpenVPN Adapter/OpenVPNAdapter+Public.h
+++ b/OpenVPN Adapter/OpenVPNAdapter+Public.h
@@ -144,7 +144,7 @@ NS_SWIFT_NAME(handle(logMessage:));
  @return <#return value description#>
  */
 - (nullable OpenVPNProperties *)applyConfiguration:(OpenVPNConfiguration *)configuration
-                     error:(out NSError * __nullable * __nullable)error
+                     error:(out NSError * _Nullable * _Nullable)error
 NS_SWIFT_NAME(apply(configuration:));
 
 /**
@@ -155,7 +155,7 @@ NS_SWIFT_NAME(apply(configuration:));
  @return <#return value description#>
  */
 - (BOOL)provideCredentials:(OpenVPNCredentials *)credentials
-                     error:(out NSError * __nullable * __nullable)error
+                     error:(out NSError * _Nullable * _Nullable)error
 NS_SWIFT_NAME(provide(credentials:));
 
 /**

--- a/OpenVPN Adapter/OpenVPNAdapter+Public.h
+++ b/OpenVPN Adapter/OpenVPNAdapter+Public.h
@@ -9,6 +9,8 @@
 #import "OpenVPNAdapterEvent.h"
 #import "OpenVPNAdapter.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class OpenVPNConfiguration;
 @class OpenVPNProperties;
 @class OpenVPNCredentials;
@@ -30,7 +32,7 @@
 
  @param completionHandler <#completionHandler description#>
  */
-- (void)readPacketsWithCompletionHandler:(nonnull void (^)(NSArray<NSData *> * _Nonnull packets, NSArray<NSNumber *> * _Nonnull protocols))completionHandler;
+- (void)readPacketsWithCompletionHandler:(void (^)(NSArray<NSData *> *packets, NSArray<NSNumber *> *protocols))completionHandler;
 
 /**
  <#Description#>
@@ -39,7 +41,7 @@
  @param protocols <#protocols description#>
  @return <#return value description#>
  */
-- (BOOL)writePackets:(nonnull NSArray<NSData *> *)packets withProtocols:(nonnull NSArray<NSNumber *> *)protocols;
+- (BOOL)writePackets:(NSArray<NSData *> *)packets withProtocols:(NSArray<NSNumber *> *)protocols;
 
 @end
 
@@ -54,8 +56,8 @@
  @param settings <#settings description#>
  @param callback <#callback description#>
  */
-- (void)configureTunnelWithSettings:(nonnull NEPacketTunnelNetworkSettings *)settings
-                 callback:(nonnull void (^)(id<OpenVPNAdapterPacketFlow> _Nullable flow))callback
+- (void)configureTunnelWithSettings:(NEPacketTunnelNetworkSettings *)settings
+                 callback:(void (^)(id<OpenVPNAdapterPacketFlow> _Nullable flow))callback
 NS_SWIFT_NAME(configureTunnel(settings:callback:));
 
 /**
@@ -73,7 +75,7 @@ NS_SWIFT_NAME(handle(event:message:));
 
  @param error <#error description#>
  */
-- (void)handleError:(nonnull NSError *)error
+- (void)handleError:(NSError *)error
 NS_SWIFT_NAME(handle(error:));
 
 @optional
@@ -83,7 +85,7 @@ NS_SWIFT_NAME(handle(error:));
 
  @param logMessage <#logMessage description#>
  */
-- (void)handleLog:(nonnull NSString *)logMessage
+- (void)handleLog:(NSString *)logMessage
 NS_SWIFT_NAME(handle(logMessage:));
 
 /**
@@ -101,12 +103,12 @@ NS_SWIFT_NAME(handle(logMessage:));
 /**
  Return core copyright
  */
-@property (class, nonnull, readonly, nonatomic) NSString *copyright;
+@property (class, readonly, nonatomic) NSString *copyright;
 
 /**
  Return platform description
  */
-@property (class, nonnull, readonly, nonatomic) NSString *platform;
+@property (class, readonly, nonatomic) NSString *platform;
 
 /**
  <#Description#>
@@ -127,12 +129,12 @@ NS_SWIFT_NAME(handle(logMessage:));
 /**
  Return transport stats
  */
-@property (nonnull, readonly, nonatomic) OpenVPNTransportStats *transportStats;
+@property (readonly, nonatomic) OpenVPNTransportStats *transportStats;
 
 /**
  Return tun stats
  */
-@property (nonnull, readonly, nonatomic) OpenVPNInterfaceStats *interfaceStats;
+@property (readonly, nonatomic) OpenVPNInterfaceStats *interfaceStats;
 
 /**
  <#Description#>
@@ -141,7 +143,7 @@ NS_SWIFT_NAME(handle(logMessage:));
  @param error <#error description#>
  @return <#return value description#>
  */
-- (nullable OpenVPNProperties *)applyConfiguration:(nonnull OpenVPNConfiguration *)configuration
+- (nullable OpenVPNProperties *)applyConfiguration:(OpenVPNConfiguration *)configuration
                      error:(out NSError * __nullable * __nullable)error
 NS_SWIFT_NAME(apply(configuration:));
 
@@ -152,7 +154,7 @@ NS_SWIFT_NAME(apply(configuration:));
  @param error <#error description#>
  @return <#return value description#>
  */
-- (BOOL)provideCredentials:(nonnull OpenVPNCredentials *)credentials
+- (BOOL)provideCredentials:(OpenVPNCredentials *)credentials
                      error:(out NSError * __nullable * __nullable)error
 NS_SWIFT_NAME(provide(credentials:));
 
@@ -189,3 +191,5 @@ NS_SWIFT_NAME(reconnect(interval:));
 - (void)disconnect;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/OpenVPN Adapter/OpenVPNAdapter+Public.h
+++ b/OpenVPN Adapter/OpenVPNAdapter+Public.h
@@ -144,7 +144,7 @@ NS_SWIFT_NAME(handle(logMessage:));
  @return <#return value description#>
  */
 - (nullable OpenVPNProperties *)applyConfiguration:(OpenVPNConfiguration *)configuration
-                     error:(out NSError * _Nullable * _Nullable)error
+                     error:(NSError **)error
 NS_SWIFT_NAME(apply(configuration:));
 
 /**
@@ -155,7 +155,7 @@ NS_SWIFT_NAME(apply(configuration:));
  @return <#return value description#>
  */
 - (BOOL)provideCredentials:(OpenVPNCredentials *)credentials
-                     error:(out NSError * _Nullable * _Nullable)error
+                     error:(NSError **)error
 NS_SWIFT_NAME(provide(credentials:));
 
 /**

--- a/OpenVPN Adapter/OpenVPNCertificate.h
+++ b/OpenVPN Adapter/OpenVPNCertificate.h
@@ -13,15 +13,15 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OpenVPNCertificate : NSObject
 
 + (nullable OpenVPNCertificate *)certificateWithPEM:(NSData *)pemData
-                                              error:(out NSError * __nullable * __nullable)error;
+                                              error:(out NSError * _Nullable * _Nullable)error;
 
 + (nullable OpenVPNCertificate *)certificateWithDER:(NSData *)derData
-                                              error:(out NSError * __nullable * __nullable)error;
+                                              error:(out NSError * _Nullable * _Nullable)error;
 
 - (instancetype) __unavailable init;
 
-- (nullable NSData *)pemData:(out NSError * __nullable * __nullable)error;
-- (nullable NSData *)derData:(out NSError * __nullable * __nullable)error;
+- (nullable NSData *)pemData:(out NSError * _Nullable * _Nullable)error;
+- (nullable NSData *)derData:(out NSError * _Nullable * _Nullable)error;
 
 @end
 

--- a/OpenVPN Adapter/OpenVPNCertificate.h
+++ b/OpenVPN Adapter/OpenVPNCertificate.h
@@ -13,15 +13,15 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OpenVPNCertificate : NSObject
 
 + (nullable OpenVPNCertificate *)certificateWithPEM:(NSData *)pemData
-                                              error:(out NSError * _Nullable * _Nullable)error;
+                                              error:(NSError **)error;
 
 + (nullable OpenVPNCertificate *)certificateWithDER:(NSData *)derData
-                                              error:(out NSError * _Nullable * _Nullable)error;
+                                              error:(NSError **)error;
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (nullable NSData *)pemData:(out NSError * _Nullable * _Nullable)error;
-- (nullable NSData *)derData:(out NSError * _Nullable * _Nullable)error;
+- (nullable NSData *)pemData:(NSError **)error;
+- (nullable NSData *)derData:(NSError **)error;
 
 @end
 

--- a/OpenVPN Adapter/OpenVPNCertificate.h
+++ b/OpenVPN Adapter/OpenVPNCertificate.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable OpenVPNCertificate *)certificateWithDER:(NSData *)derData
                                               error:(out NSError * _Nullable * _Nullable)error;
 
-- (instancetype) __unavailable init;
+- (instancetype)init NS_UNAVAILABLE;
 
 - (nullable NSData *)pemData:(out NSError * _Nullable * _Nullable)error;
 - (nullable NSData *)derData:(out NSError * _Nullable * _Nullable)error;

--- a/OpenVPN Adapter/OpenVPNCertificate.h
+++ b/OpenVPN Adapter/OpenVPNCertificate.h
@@ -8,17 +8,21 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface OpenVPNCertificate : NSObject
 
-+ (nullable OpenVPNCertificate *)certificateWithPEM:(nonnull NSData *)pemData
++ (nullable OpenVPNCertificate *)certificateWithPEM:(NSData *)pemData
                                               error:(out NSError * __nullable * __nullable)error;
 
-+ (nullable OpenVPNCertificate *)certificateWithDER:(nonnull NSData *)derData
++ (nullable OpenVPNCertificate *)certificateWithDER:(NSData *)derData
                                               error:(out NSError * __nullable * __nullable)error;
 
-- (nonnull instancetype) __unavailable init;
+- (instancetype) __unavailable init;
 
 - (nullable NSData *)pemData:(out NSError * __nullable * __nullable)error;
 - (nullable NSData *)derData:(out NSError * __nullable * __nullable)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/OpenVPN Adapter/OpenVPNConfiguration+Internal.h
+++ b/OpenVPN Adapter/OpenVPNConfiguration+Internal.h
@@ -10,6 +10,8 @@
 
 #import "OpenVPNConfiguration.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 using namespace openvpn;
 
 @interface OpenVPNConfiguration (Internal)
@@ -17,18 +19,20 @@ using namespace openvpn;
 @property (readonly) ClientAPI::Config config;
 
 + (OpenVPNTransportProtocol)getTransportProtocolFromValue:(nullable NSString *)value;
-+ (nonnull NSString *)getValueFromTransportProtocol:(OpenVPNTransportProtocol)protocol;
++ (NSString *)getValueFromTransportProtocol:(OpenVPNTransportProtocol)protocol;
 
 + (OpenVPNIPv6Preference)getIPv6PreferenceFromValue:(nullable NSString *)value;
-+ (nonnull NSString *)getValueFromIPv6Preference:(OpenVPNIPv6Preference)preference;
++ (NSString *)getValueFromIPv6Preference:(OpenVPNIPv6Preference)preference;
 
 + (OpenVPNCompressionMode)getCompressionModeFromValue:(nullable NSString *)value;
-+ (nonnull NSString *)getValueFromCompressionMode:(OpenVPNCompressionMode)compressionMode;
++ (NSString *)getValueFromCompressionMode:(OpenVPNCompressionMode)compressionMode;
 
 + (OpenVPNMinTLSVersion)getMinTLSFromValue:(nullable NSString *)value;
-+ (nonnull NSString *)getValueFromMinTLS:(OpenVPNMinTLSVersion)minTLS;
++ (NSString *)getValueFromMinTLS:(OpenVPNMinTLSVersion)minTLS;
 
 + (OpenVPNTLSCertProfile)getTLSCertProfileFromValue:(nullable NSString *)value;
-+ (nonnull NSString *)getValueFromTLSCertProfile:(OpenVPNTLSCertProfile)tlsCertProfile;
++ (NSString *)getValueFromTLSCertProfile:(OpenVPNTLSCertProfile)tlsCertProfile;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/OpenVPN Adapter/OpenVPNError.h
+++ b/OpenVPN Adapter/OpenVPNError.h
@@ -8,11 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
-FOUNDATION_EXPORT NSString * __nonnull const OpenVPNAdapterErrorDomain;
-FOUNDATION_EXPORT NSString * __nonnull const OpenVPNIdentityErrorDomain;
+NS_ASSUME_NONNULL_BEGIN
 
-FOUNDATION_EXPORT NSString * __nonnull const OpenVPNAdapterErrorFatalKey;
-FOUNDATION_EXPORT NSString * __nonnull const OpenVPNAdapterErrorMessageKey;
+FOUNDATION_EXPORT NSString * const OpenVPNAdapterErrorDomain;
+FOUNDATION_EXPORT NSString * const OpenVPNIdentityErrorDomain;
+
+FOUNDATION_EXPORT NSString * const OpenVPNAdapterErrorFatalKey;
+FOUNDATION_EXPORT NSString * const OpenVPNAdapterErrorMessageKey;
 
 /**
  OpenVPN error codes
@@ -85,3 +87,5 @@ typedef NS_ENUM(NSInteger, OpenVPNAdapterError) {
     OpenVPNAdapterErrorEPKIInvalidAlias,
     OpenVPNAdapterErrorUnknown
 };
+
+NS_ASSUME_NONNULL_END

--- a/OpenVPN Adapter/OpenVPNPrivateKey.h
+++ b/OpenVPN Adapter/OpenVPNPrivateKey.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
                                   password:(nullable NSString *)password
                                      error:(out NSError * _Nullable * _Nullable)error;
 
-- (instancetype) __unavailable init;
+- (instancetype)init NS_UNAVAILABLE;
 
 @property (nonatomic, readonly) NSInteger size;
 @property (nonatomic, readonly) OpenVPNKeyType type;

--- a/OpenVPN Adapter/OpenVPNPrivateKey.h
+++ b/OpenVPN Adapter/OpenVPNPrivateKey.h
@@ -16,19 +16,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable OpenVPNPrivateKey *)keyWithPEM:(NSData *)pemData
                                   password:(nullable NSString *)password
-                                     error:(out NSError * _Nullable * _Nullable)error;
+                                     error:(NSError **)error;
 
 + (nullable OpenVPNPrivateKey *)keyWithDER:(NSData *)derData
                                   password:(nullable NSString *)password
-                                     error:(out NSError * _Nullable * _Nullable)error;
+                                     error:(NSError **)error;
 
 - (instancetype)init NS_UNAVAILABLE;
 
 @property (nonatomic, readonly) NSInteger size;
 @property (nonatomic, readonly) OpenVPNKeyType type;
 
-- (nullable NSData *)pemData:(out NSError * _Nullable * _Nullable)error;
-- (nullable NSData *)derData:(out NSError * _Nullable * _Nullable)error;
+- (nullable NSData *)pemData:(NSError **)error;
+- (nullable NSData *)derData:(NSError **)error;
 
 @end
 

--- a/OpenVPN Adapter/OpenVPNPrivateKey.h
+++ b/OpenVPN Adapter/OpenVPNPrivateKey.h
@@ -10,17 +10,19 @@
 
 #import "OpenVPNKeyType.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface OpenVPNPrivateKey : NSObject
 
-+ (nullable OpenVPNPrivateKey *)keyWithPEM:(nonnull NSData *)pemData
++ (nullable OpenVPNPrivateKey *)keyWithPEM:(NSData *)pemData
                                   password:(nullable NSString *)password
                                      error:(out NSError * __nullable * __nullable)error;
 
-+ (nullable OpenVPNPrivateKey *)keyWithDER:(nonnull NSData *)derData
++ (nullable OpenVPNPrivateKey *)keyWithDER:(NSData *)derData
                                   password:(nullable NSString *)password
                                      error:(out NSError * __nullable * __nullable)error;
 
-- (nonnull instancetype) __unavailable init;
+- (instancetype) __unavailable init;
 
 @property (nonatomic, readonly) NSInteger size;
 @property (nonatomic, readonly) OpenVPNKeyType type;
@@ -29,3 +31,5 @@
 - (nullable NSData *)derData:(out NSError * __nullable * __nullable)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/OpenVPN Adapter/OpenVPNPrivateKey.h
+++ b/OpenVPN Adapter/OpenVPNPrivateKey.h
@@ -16,19 +16,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable OpenVPNPrivateKey *)keyWithPEM:(NSData *)pemData
                                   password:(nullable NSString *)password
-                                     error:(out NSError * __nullable * __nullable)error;
+                                     error:(out NSError * _Nullable * _Nullable)error;
 
 + (nullable OpenVPNPrivateKey *)keyWithDER:(NSData *)derData
                                   password:(nullable NSString *)password
-                                     error:(out NSError * __nullable * __nullable)error;
+                                     error:(out NSError * _Nullable * _Nullable)error;
 
 - (instancetype) __unavailable init;
 
 @property (nonatomic, readonly) NSInteger size;
 @property (nonatomic, readonly) OpenVPNKeyType type;
 
-- (nullable NSData *)pemData:(out NSError * __nullable * __nullable)error;
-- (nullable NSData *)derData:(out NSError * __nullable * __nullable)error;
+- (nullable NSData *)pemData:(out NSError * _Nullable * _Nullable)error;
+- (nullable NSData *)derData:(out NSError * _Nullable * _Nullable)error;
 
 @end
 

--- a/OpenVPN Adapter/OpenVPNProperties.h
+++ b/OpenVPN Adapter/OpenVPNProperties.h
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nullable, readonly, nonatomic) NSArray<OpenVPNServerEntry *> *servers;
 
-- (instancetype) __unavailable init;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/OpenVPN Adapter/OpenVPNProperties.h
+++ b/OpenVPN Adapter/OpenVPNProperties.h
@@ -10,6 +10,8 @@
 
 #import "OpenVPNTransportProtocol.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class OpenVPNServerEntry;
 
 @interface OpenVPNProperties : NSObject
@@ -74,6 +76,8 @@
  */
 @property (nullable, readonly, nonatomic) NSArray<OpenVPNServerEntry *> *servers;
 
-- (nonnull instancetype) __unavailable init;
+- (instancetype) __unavailable init;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/OpenVPN Adapter/OpenVPNReachability.h
+++ b/OpenVPN Adapter/OpenVPNReachability.h
@@ -9,14 +9,18 @@
 #import <Foundation/Foundation.h>
 #import "OpenVPNReachabilityStatus.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface OpenVPNReachability : NSObject
 
 @property (readonly, nonatomic) BOOL isTracking;
 @property (readonly, nonatomic) OpenVPNReachabilityStatus reachabilityStatus;
 
-- (nonnull instancetype)init;
+- (instancetype)init;
 
 - (void)startTrackingWithCallback:(nullable void (^)(OpenVPNReachabilityStatus))callback;
 - (void)stopTracking;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/OpenVPN Adapter/OpenVPNServerEntry.h
+++ b/OpenVPN Adapter/OpenVPNServerEntry.h
@@ -8,11 +8,15 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface OpenVPNServerEntry : NSObject
 
 @property (nullable, readonly, nonatomic) NSString *server;
 @property (nullable, readonly, nonatomic) NSString *friendlyName;
 
-- (nonnull instancetype) __unavailable init;
+- (instancetype) __unavailable init;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/OpenVPN Adapter/OpenVPNServerEntry.h
+++ b/OpenVPN Adapter/OpenVPNServerEntry.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, readonly, nonatomic) NSString *server;
 @property (nullable, readonly, nonatomic) NSString *friendlyName;
 
-- (instancetype) __unavailable init;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/OpenVPN Adapter/OpenVPNTunnelSettings.h
+++ b/OpenVPN Adapter/OpenVPNTunnelSettings.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface OpenVPNTunnelSettings : NSObject
 
 @property (nonatomic) BOOL initialized;
@@ -21,3 +23,5 @@
 @property (readonly, strong, nonatomic) NSMutableArray *dnsAddresses;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This is a minor change which replaces the use of `nonnull` annotations with blanket [`NS_ASSUME_NONNULL_BEGIN/END`](https://developer.apple.com/swift/blog/?id=25) calls.

It also updates `__nullable` to `_Nullable`, in the same vein.

Additionally, `__unavailable` can be replaced with `NS_UNAVAILABLE`.

This practice is seen in many Apple header files and I would encourage the use of it here too.

Thanks as always with your support with all these admittedly minor changes.