### PR TITLE
Change -establishTunnel Return Type

### DIFF
--- a/OpenVPN Adapter/OpenVPNAdapter+Internal.h
+++ b/OpenVPN Adapter/OpenVPNAdapter+Internal.h
@@ -29,7 +29,7 @@ using namespace openvpn;
 
 - (BOOL)setMTU:(NSNumber *)mtu;
 
-- (NSInteger)establishTunnel;
+- (CFSocketNativeHandle)establishTunnel;
 
 - (void)handleEvent:(const ClientAPI::Event *)event;
 - (void)handleLog:(const ClientAPI::LogInfo *)log;

--- a/OpenVPN Adapter/OpenVPNAdapter.mm
+++ b/OpenVPN Adapter/OpenVPNAdapter.mm
@@ -257,7 +257,7 @@ static void socketCallback(CFSocketRef socket, CFSocketCallBackType type, CFData
     return YES;
 }
 
-- (NSInteger)establishTunnel {
+- (CFSocketNativeHandle)establishTunnel {
     NSAssert(self.delegate != nil, @"delegate property should not be nil");
     
     NEPacketTunnelNetworkSettings *networkSettings = [[NEPacketTunnelNetworkSettings alloc] initWithTunnelRemoteAddress:self.remoteAddress];


### PR DESCRIPTION
This is a straightforward commit which aims to improve the documentation of the framework.

The return type of `CFSocketGetNative` which `-establishTunnel` returns, is `CFSocketNativeHandle` rather than `NSInteger`.

Despite the fact that `CFSocketNativeHandle` is a typedef of `int`, I feel this PR still has merit as it improves the documentation of the class and therefore aids future developers whom may wish to improve this library.

I hope this PR doesn't come across pedantic or pointless.