### PR TITLE
Add OpenVPNTunnelProvider: A Convenient NEPacketTunnelProvider Subclass

### DIFF
--- a/OpenVPN Adapter.xcodeproj/project.pbxproj
+++ b/OpenVPN Adapter.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AB7DF70B1F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = AB7DF7091F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AB7DF70C1F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = AB7DF7091F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AB7DF70D1F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = AB7DF70A1F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.m */; };
+		AB7DF70E1F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = AB7DF70A1F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.m */; };
 		AB88AEDA1F7BDDFC00D5C3CD /* OpenVPNTunnelProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = AB88AED81F7BDDE400D5C3CD /* OpenVPNTunnelProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AB88AEDB1F7BDDFC00D5C3CD /* OpenVPNTunnelProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = AB88AED81F7BDDE400D5C3CD /* OpenVPNTunnelProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AB88AEDC1F7BDE0600D5C3CD /* OpenVPNTunnelProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = AB88AED71F7BDDE400D5C3CD /* OpenVPNTunnelProvider.m */; };
@@ -170,6 +174,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AB7DF7091F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NEVPNProtocol+OpenVPNAdapter.h"; sourceTree = "<group>"; };
+		AB7DF70A1F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NEVPNProtocol+OpenVPNAdapter.m"; sourceTree = "<group>"; };
 		AB88AED71F7BDDE400D5C3CD /* OpenVPNTunnelProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OpenVPNTunnelProvider.m; sourceTree = "<group>"; };
 		AB88AED81F7BDDE400D5C3CD /* OpenVPNTunnelProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OpenVPNTunnelProvider.h; sourceTree = "<group>"; };
 		C90BAD261E73F47E00DEFB32 /* Info-Framework.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Framework.plist"; sourceTree = "<group>"; };
@@ -297,6 +303,8 @@
 			children = (
 				AB88AED81F7BDDE400D5C3CD /* OpenVPNTunnelProvider.h */,
 				AB88AED71F7BDDE400D5C3CD /* OpenVPNTunnelProvider.m */,
+				AB7DF7091F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.h */,
+				AB7DF70A1F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.m */,
 			);
 			name = "Tunnel Provider";
 			sourceTree = "<group>";
@@ -591,6 +599,7 @@
 				C9657A2B1EB0B6FA00EFF210 /* OpenVPNTransportStats+Internal.h in Headers */,
 				C9BB47601E71663A00F3F98C /* Umbrella-Header.h in Headers */,
 				C9657A5E1EB0D60700EFF210 /* OpenVPNTransportProtocol.h in Headers */,
+				AB7DF70B1F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.h in Headers */,
 				C9657A1D1EB0A8D800EFF210 /* OpenVPNConnectionInfo+Internal.h in Headers */,
 				C9B7955E1F1D16AA00CF35FE /* OpenVPNReachability.h in Headers */,
 				C915F1F41F612F3300B3DF23 /* OpenVPNPrivateKey.h in Headers */,
@@ -637,6 +646,7 @@
 				C9657A2F1EB0B79500EFF210 /* OpenVPNTransportStats+Internal.h in Headers */,
 				C9D2ABE61EA20F99007EDF9D /* Umbrella-Header.h in Headers */,
 				C9657A5F1EB0D60700EFF210 /* OpenVPNTransportProtocol.h in Headers */,
+				AB7DF70C1F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.h in Headers */,
 				C9657A1E1EB0A8D800EFF210 /* OpenVPNConnectionInfo+Internal.h in Headers */,
 				C9B7955F1F1D16AA00CF35FE /* OpenVPNReachability.h in Headers */,
 				C915F1F51F612F3300B3DF23 /* OpenVPNPrivateKey.h in Headers */,
@@ -866,6 +876,7 @@
 				C9BCE25A1EB3C0D9009D6AC1 /* OpenVPNSessionToken.mm in Sources */,
 				C9BB47821E7173C700F3F98C /* OpenVPNAdapter.mm in Sources */,
 				C98467A81EAA5B7700272A9A /* OpenVPNConfiguration.mm in Sources */,
+				AB7DF70D1F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.m in Sources */,
 				C9E4401F1F6086A1001D7C41 /* NSError+Message.m in Sources */,
 				C9BDB1371EBCC3B900C204FF /* OpenVPNTunnelSettings.m in Sources */,
 				C9657A311EB0B7A900EFF210 /* OpenVPNTransportStats.mm in Sources */,
@@ -905,6 +916,7 @@
 				C9BCE25B1EB3C0D9009D6AC1 /* OpenVPNSessionToken.mm in Sources */,
 				C9D2ABDB1EA20F99007EDF9D /* OpenVPNAdapter.mm in Sources */,
 				C98467A91EAA5B7700272A9A /* OpenVPNConfiguration.mm in Sources */,
+				AB7DF70E1F7D730E00D6E4BF /* NEVPNProtocol+OpenVPNAdapter.m in Sources */,
 				C9E440201F6086A1001D7C41 /* NSError+Message.m in Sources */,
 				C9BDB1381EBCC3B900C204FF /* OpenVPNTunnelSettings.m in Sources */,
 				C9657A301EB0B7A600EFF210 /* OpenVPNTransportStats.mm in Sources */,

--- a/OpenVPN Adapter.xcodeproj/project.pbxproj
+++ b/OpenVPN Adapter.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AB88AEDA1F7BDDFC00D5C3CD /* OpenVPNTunnelProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = AB88AED81F7BDDE400D5C3CD /* OpenVPNTunnelProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AB88AEDB1F7BDDFC00D5C3CD /* OpenVPNTunnelProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = AB88AED81F7BDDE400D5C3CD /* OpenVPNTunnelProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AB88AEDC1F7BDE0600D5C3CD /* OpenVPNTunnelProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = AB88AED71F7BDDE400D5C3CD /* OpenVPNTunnelProvider.m */; };
+		AB88AEDD1F7BDE0700D5C3CD /* OpenVPNTunnelProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = AB88AED71F7BDDE400D5C3CD /* OpenVPNTunnelProvider.m */; };
 		C90BAD311E73FF6C00DEFB32 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C90BAD301E73FF6C00DEFB32 /* SystemConfiguration.framework */; };
 		C912BB251E7C3339002B9414 /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C912BB241E7C3339002B9414 /* NetworkExtension.framework */; };
 		C915F1F41F612F3300B3DF23 /* OpenVPNPrivateKey.h in Headers */ = {isa = PBXBuildFile; fileRef = C915F1F21F612F3300B3DF23 /* OpenVPNPrivateKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -166,6 +170,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AB88AED71F7BDDE400D5C3CD /* OpenVPNTunnelProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OpenVPNTunnelProvider.m; sourceTree = "<group>"; };
+		AB88AED81F7BDDE400D5C3CD /* OpenVPNTunnelProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OpenVPNTunnelProvider.h; sourceTree = "<group>"; };
 		C90BAD261E73F47E00DEFB32 /* Info-Framework.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Framework.plist"; sourceTree = "<group>"; };
 		C90BAD271E73F47E00DEFB32 /* Info-Tests.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Tests.plist"; sourceTree = "<group>"; };
 		C90BAD291E73F56800DEFB32 /* Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Framework.xcconfig; sourceTree = "<group>"; };
@@ -286,6 +292,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AB88AED91F7BDDEB00D5C3CD /* Tunnel Provider */ = {
+			isa = PBXGroup;
+			children = (
+				AB88AED81F7BDDE400D5C3CD /* OpenVPNTunnelProvider.h */,
+				AB88AED71F7BDDE400D5C3CD /* OpenVPNTunnelProvider.m */,
+			);
+			name = "Tunnel Provider";
+			sourceTree = "<group>";
+		};
 		C90BAD251E73F47E00DEFB32 /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
@@ -408,6 +423,7 @@
 				C9235AC41EB24F0100C7D303 /* Configuration */,
 				C9235AC51EB24F1100C7D303 /* Stats and Info */,
 				C9BB47671E7169F000F3F98C /* Adapter */,
+				AB88AED91F7BDDEB00D5C3CD /* Tunnel Provider */,
 				C9BB47641E7169AF00F3F98C /* Libraries */,
 				C9BB47651E7169B700F3F98C /* Framework */,
 			);
@@ -584,6 +600,7 @@
 				C9B795641F1D182500CF35FE /* OpenVPNReachabilityTracker.h in Headers */,
 				C9BB47801E7173C700F3F98C /* OpenVPNAdapter+Internal.h in Headers */,
 				C9E4401D1F6086A1001D7C41 /* NSError+Message.h in Headers */,
+				AB88AEDA1F7BDDFC00D5C3CD /* OpenVPNTunnelProvider.h in Headers */,
 				C9657A611EB0D64E00EFF210 /* OpenVPNIPv6Preference.h in Headers */,
 				C9657A671EB0D73200EFF210 /* OpenVPNMinTLSVersion.h in Headers */,
 				C93779D51EAE32670030A362 /* OpenVPNCredentials.h in Headers */,
@@ -629,6 +646,7 @@
 				C9B795651F1D182500CF35FE /* OpenVPNReachabilityTracker.h in Headers */,
 				C9D2ABE91EA20F99007EDF9D /* OpenVPNAdapter+Internal.h in Headers */,
 				C9E4401E1F6086A1001D7C41 /* NSError+Message.h in Headers */,
+				AB88AEDB1F7BDDFC00D5C3CD /* OpenVPNTunnelProvider.h in Headers */,
 				C9657A621EB0D64E00EFF210 /* OpenVPNIPv6Preference.h in Headers */,
 				C9657A681EB0D73200EFF210 /* OpenVPNMinTLSVersion.h in Headers */,
 				C93779D61EAE32670030A362 /* OpenVPNCredentials.h in Headers */,
@@ -843,6 +861,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AB88AEDD1F7BDE0700D5C3CD /* OpenVPNTunnelProvider.m in Sources */,
 				C9657A421EB0CAC200EFF210 /* OpenVPNServerEntry.mm in Sources */,
 				C9BCE25A1EB3C0D9009D6AC1 /* OpenVPNSessionToken.mm in Sources */,
 				C9BB47821E7173C700F3F98C /* OpenVPNAdapter.mm in Sources */,
@@ -881,6 +900,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AB88AEDC1F7BDE0600D5C3CD /* OpenVPNTunnelProvider.m in Sources */,
 				C9657A431EB0CAC200EFF210 /* OpenVPNServerEntry.mm in Sources */,
 				C9BCE25B1EB3C0D9009D6AC1 /* OpenVPNSessionToken.mm in Sources */,
 				C9D2ABDB1EA20F99007EDF9D /* OpenVPNAdapter.mm in Sources */,

--- a/OpenVPN Adapter/NEVPNProtocol+OpenVPNAdapter.h
+++ b/OpenVPN Adapter/NEVPNProtocol+OpenVPNAdapter.h
@@ -1,0 +1,25 @@
+//
+//  NEVPNProtocol+OpenVPNAdapter.h
+//  OpenVPN Adapter
+//
+//  Created by Jonathan Downing on 28/09/2017.
+//
+
+@import NetworkExtension;
+
+@class OpenVPNConfiguration;
+@class OpenVPNCredentials;
+
+@interface NEVPNProtocol (OpenVPNAdapter)
+
+/*
+ The configuration object for the OpenVPN session.
+ */
+@property (nonatomic, nullable) OpenVPNConfiguration *openVPNConfiguration;
+
+/*
+ The credentials object for the OpenVPN session, derived from the username and passwordReference properties on self.
+ */
+@property (nonatomic, nullable, readonly) OpenVPNCredentials *openVPNCredentials;
+
+@end

--- a/OpenVPN Adapter/NEVPNProtocol+OpenVPNAdapter.m
+++ b/OpenVPN Adapter/NEVPNProtocol+OpenVPNAdapter.m
@@ -1,0 +1,60 @@
+//
+//  NEVPNProtocol+OpenVPNConfiguration.m
+//  OpenVPN Adapter
+//
+//  Created by Jonathan Downing on 28/09/2017.
+//
+
+#import "NEVPNProtocol+OpenVPNAdapter.h"
+
+#import "OpenVPNConfiguration.h"
+#import "OpenVPNCredentials.h"
+
+NSString * const OpenVPNAdapterConfigurationKey = @"OpenVPNAdapterConfigurationKey";
+
+@implementation NEVPNProtocol (OpenVPNAdapter)
+
+- (id)providerObjectOfClass:(Class)class ForKey:(NSString *)key {
+    if (![self isKindOfClass:[NETunnelProviderProtocol class]]) return nil;
+    id data = ((NETunnelProviderProtocol *)self).providerConfiguration[key];
+    if (![data isKindOfClass:[NSData class]]) return nil;
+    id object = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    if (![object isKindOfClass:class]) return nil;
+    return object;
+}
+
+- (void)setProviderConfigurationObject:(id<NSSecureCoding>)object forKey:(NSString *)key {
+    if (![self isKindOfClass:[NETunnelProviderProtocol class]]) return;
+    NSMutableDictionary *providerConfiguration = [((NETunnelProviderProtocol *)self).providerConfiguration mutableCopy] ?: [[NSMutableDictionary alloc] init];
+    providerConfiguration[key] = object ? [NSKeyedArchiver archivedDataWithRootObject:object] : nil;
+    ((NETunnelProviderProtocol *)self).providerConfiguration = [providerConfiguration copy];
+}
+
+- (OpenVPNConfiguration *)openVPNConfiguration {
+    return [self providerObjectOfClass:[OpenVPNConfiguration class] ForKey:OpenVPNAdapterConfigurationKey];
+}
+
+- (void)setOpenVPNConfiguration:(OpenVPNConfiguration *)openVPNConfiguration {
+    [self setProviderConfigurationObject:openVPNConfiguration forKey:OpenVPNAdapterConfigurationKey];
+}
+
+- (OpenVPNCredentials *)openVPNCredentials {
+    if (!self.username.length) return nil;
+    if (!self.passwordReference) return nil;
+    
+    CFTypeRef reference;
+    NSDictionary *query = @{(id)kSecClass: (id)kSecClassGenericPassword,
+                            (id)kSecReturnData: (id)kCFBooleanTrue,
+                            (id)kSecValuePersistentRef: self.passwordReference};
+    if (SecItemCopyMatching((__bridge CFDictionaryRef)query, &reference) != errSecSuccess) return nil;
+    
+    NSString *password = [[NSString alloc] initWithData:(__bridge NSData *)reference encoding:NSUTF8StringEncoding];
+    if (!password.length) return nil;
+    
+    OpenVPNCredentials *credentials = [[OpenVPNCredentials alloc] init];
+    credentials.username = self.username;
+    credentials.password = password;
+    return credentials;
+}
+
+@end

--- a/OpenVPN Adapter/NEVPNProtocol+OpenVPNAdapter.m
+++ b/OpenVPN Adapter/NEVPNProtocol+OpenVPNAdapter.m
@@ -14,7 +14,7 @@ NSString * const OpenVPNAdapterConfigurationKey = @"OpenVPNAdapterConfigurationK
 
 @implementation NEVPNProtocol (OpenVPNAdapter)
 
-- (id)providerObjectOfClass:(Class)class ForKey:(NSString *)key {
+- (id)providerObjectOfClass:(Class)class forKey:(NSString *)key {
     if (![self isKindOfClass:[NETunnelProviderProtocol class]]) return nil;
     id data = ((NETunnelProviderProtocol *)self).providerConfiguration[key];
     if (![data isKindOfClass:[NSData class]]) return nil;
@@ -31,7 +31,7 @@ NSString * const OpenVPNAdapterConfigurationKey = @"OpenVPNAdapterConfigurationK
 }
 
 - (OpenVPNConfiguration *)openVPNConfiguration {
-    return [self providerObjectOfClass:[OpenVPNConfiguration class] ForKey:OpenVPNAdapterConfigurationKey];
+    return [self providerObjectOfClass:[OpenVPNConfiguration class] forKey:OpenVPNAdapterConfigurationKey];
 }
 
 - (void)setOpenVPNConfiguration:(OpenVPNConfiguration *)openVPNConfiguration {

--- a/OpenVPN Adapter/OpenVPNTunnelProvider.h
+++ b/OpenVPN Adapter/OpenVPNTunnelProvider.h
@@ -1,0 +1,35 @@
+//
+//  OpenVPNTunnelProvider.h
+//  OpenVPN Adapter
+//
+//  Created by Jonathan Downing on 26/09/2017.
+//
+
+#import <NetworkExtension/NetworkExtension.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class OpenVPNConfiguration;
+@class OpenVPNCredentials;
+
+extern NSString * const OpenVPNTunnelProviderConfigurationKey;
+
+/*!
+ * @interface OpenVPNTunnelProvider
+ * @discussion The OpenVPNTunnelProvider subclass is a convenient way to use OpenVPNAdapter in conjunction with the NetworkExtension framework.
+ *
+ * OpenVPNTunnelProvider is a subclass of NEPacketTunnelProvider which provides all the necessary logic to establish an OpenVPN tunnel via a Packet Tunnel Provider Extension.
+ *
+ * In order to provide an OpenVPNConfiguration object to OpenVPNTunnelProvider, the following procedure must be followed:
+ * 1) Create a valid OpenVPNConfiguration object with the desired configuration,
+ * 2) Convert it to an NSData object via NSKeyedArchiver
+ * 3) Add this data object to the providerConfiguration dictionary on NETunnelProviderProtocol using OpenVPNTunnelProviderConfigurationKey as the key.
+ *
+ * Credentials are aquired using the username and passwordReference properties on NETunnelProviderProtocol.
+ * @note Only username/password or client certificate authentication is supported when using OpenVPNTunnelProvider.
+ */
+@interface OpenVPNTunnelProvider : NEPacketTunnelProvider
+
+@end
+           
+NS_ASSUME_NONNULL_END

--- a/OpenVPN Adapter/OpenVPNTunnelProvider.h
+++ b/OpenVPN Adapter/OpenVPNTunnelProvider.h
@@ -9,8 +9,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class OpenVPNAdapter;
 @class OpenVPNConfiguration;
+@class OpenVPNConnectionInfo;
 @class OpenVPNCredentials;
+@class OpenVPNConnectionInfo;
+@class OpenVPNInterfaceStats;
+@class OpenVPNSessionToken;
+@class OpenVPNTransportStats;
 
 extern NSString * const OpenVPNTunnelProviderConfigurationKey;
 
@@ -29,6 +35,26 @@ extern NSString * const OpenVPNTunnelProviderConfigurationKey;
  * @note Only username/password or client certificate authentication is supported when using OpenVPNTunnelProvider.
  */
 @interface OpenVPNTunnelProvider : NEPacketTunnelProvider
+
+/**
+ Returns information about the most recent connection once the tunnel connection state is connected, otherwise nil.
+ */
+@property (nonatomic, readonly, nullable) OpenVPNConnectionInfo *connectionInformation;
+
+/**
+ Return current session token if available, otherwise nil.
+ */
+@property (nonatomic, readonly, nullable) OpenVPNSessionToken *sessionToken;
+
+/**
+ Return transport statistics.
+ */
+@property (nonatomic, readonly) OpenVPNTransportStats *transportStatistics;
+
+/**
+ Return tunnel interface statistics.
+ */
+@property (nonatomic, readonly) OpenVPNInterfaceStats *interfaceStatistics;
 
 @end
            

--- a/OpenVPN Adapter/OpenVPNTunnelProvider.h
+++ b/OpenVPN Adapter/OpenVPNTunnelProvider.h
@@ -5,7 +5,7 @@
 //  Created by Jonathan Downing on 26/09/2017.
 //
 
-#import <NetworkExtension/NetworkExtension.h>
+@import NetworkExtension;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/OpenVPN Adapter/OpenVPNTunnelProvider.h
+++ b/OpenVPN Adapter/OpenVPNTunnelProvider.h
@@ -9,16 +9,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class OpenVPNAdapter;
-@class OpenVPNConfiguration;
-@class OpenVPNConnectionInfo;
-@class OpenVPNCredentials;
 @class OpenVPNConnectionInfo;
 @class OpenVPNInterfaceStats;
 @class OpenVPNSessionToken;
 @class OpenVPNTransportStats;
-
-extern NSString * const OpenVPNTunnelProviderConfigurationKey;
 
 /*!
  * @interface OpenVPNTunnelProvider
@@ -26,12 +20,9 @@ extern NSString * const OpenVPNTunnelProviderConfigurationKey;
  *
  * OpenVPNTunnelProvider is a subclass of NEPacketTunnelProvider which provides all the necessary logic to establish an OpenVPN tunnel via a Packet Tunnel Provider Extension.
  *
- * In order to provide an OpenVPNConfiguration object to OpenVPNTunnelProvider, the following procedure must be followed:
- * 1) Create a valid OpenVPNConfiguration object with the desired configuration,
- * 2) Convert it to an NSData object via NSKeyedArchiver
- * 3) Add this data object to the providerConfiguration dictionary on NETunnelProviderProtocol using OpenVPNTunnelProviderConfigurationKey as the key.
+ * In order to provide an OpenVPNConfiguration object to OpenVPNTunnelProvider, set the openVPNConfiguration property on NEVPNProtocol.
  *
- * Credentials are aquired using the username and passwordReference properties on NETunnelProviderProtocol.
+ * Credentials are aquired using the username and passwordReference properties on NEVPNProtocol.
  * @note Only username/password or client certificate authentication is supported when using OpenVPNTunnelProvider.
  */
 @interface OpenVPNTunnelProvider : NEPacketTunnelProvider

--- a/OpenVPN Adapter/OpenVPNTunnelProvider.m
+++ b/OpenVPN Adapter/OpenVPNTunnelProvider.m
@@ -1,0 +1,158 @@
+//
+//  OpenVPNTunnelProvider.m
+//  OpenVPN Adapter
+//
+//  Created by Jonathan Downing on 26/09/2017.
+//
+
+#import "OpenVPNTunnelProvider.h"
+
+#import "OpenVPNAdapter.h"
+#import "OpenVPNAdapter+Public.h"
+#import "OpenVPNConfiguration.h"
+#import "OpenVPNCredentials.h"
+#import "OpenVPNError.h"
+#import "OpenVPNProperties.h"
+#import "OpenVPNReachability.h"
+
+NSString * const OpenVPNTunnelProviderConfigurationKey = @"OpenVPNTunnelProviderConfigurationKey";
+
+@interface NEPacketTunnelFlow () <OpenVPNAdapterPacketFlow>
+@end
+
+@interface OpenVPNTunnelProvider () <OpenVPNAdapterDelegate>
+@property (nonatomic, copy) void (^startCompletionHandler)(NSError *);
+@property (nonatomic, copy) void (^stopCompletionHandler)(void);
+@property (nonatomic) OpenVPNAdapter *adapter;
+@property (nonatomic) OpenVPNReachability *reachability;
+@end
+
+@implementation OpenVPNTunnelProvider
+
+- (void)startTunnelWithOptions:(NSDictionary<NSString *,NSObject *> *)options completionHandler:(void (^)(NSError * _Nullable))completionHandler {
+    NSError *error;
+    
+    if (!self.configuration) {
+        completionHandler([NSError errorWithDomain:NEVPNErrorDomain code:NEVPNErrorConfigurationInvalid userInfo:nil]);
+        return;
+    }
+    
+    OpenVPNProperties *properties = [self.adapter applyConfiguration:self.configuration error:&error];
+    
+    if (!properties) {
+        completionHandler(error);
+        return;
+    }
+    
+    if (!properties.autologin) {
+        if (!self.credentials) {
+            completionHandler([NSError errorWithDomain:NEVPNErrorDomain code:NEVPNErrorConfigurationInvalid userInfo:nil]);
+            return;
+        } else if (![self.adapter provideCredentials:self.credentials error:&error]) {
+            completionHandler(error);
+            return;
+        }
+    }
+    
+    self.startCompletionHandler = completionHandler;
+    
+    __weak typeof(self) weakSelf = self;
+    [self.reachability startTrackingWithCallback:^(OpenVPNReachabilityStatus status) {
+        typeof(self) strongSelf = weakSelf;
+        if (status != OpenVPNReachabilityStatusNotReachable) {
+            [strongSelf.adapter reconnectAfterTimeInterval:0];
+        }
+    }];
+    
+    [self.adapter connect];
+}
+
+- (void)stopTunnelWithReason:(NEProviderStopReason)reason completionHandler:(void (^)(void))completionHandler {
+    self.stopCompletionHandler = completionHandler;
+    [self.adapter disconnect];
+}
+
+- (void)configureTunnelWithSettings:(NEPacketTunnelNetworkSettings *)settings callback:(void (^)(id<OpenVPNAdapterPacketFlow> _Nullable))callback {
+    __weak typeof(self) weakSelf = self;
+    [self setTunnelNetworkSettings:settings completionHandler:^(NSError * _Nullable error) {
+        typeof(self) strongSelf = weakSelf;
+        callback(!error ? strongSelf.packetFlow : nil);
+    }];
+}
+
+- (void)handleEvent:(OpenVPNAdapterEvent)event message:(nullable NSString *)message {
+    switch (event) {
+        case OpenVPNAdapterEventConnected:
+            self.reasserting = NO;
+            if (self.startCompletionHandler) self.startCompletionHandler(nil);
+            self.startCompletionHandler = nil;
+            break;
+        case OpenVPNAdapterEventReconnecting:
+            self.reasserting = YES;
+            break;
+        case OpenVPNAdapterEventDisconnected:
+            if (self.stopCompletionHandler) self.stopCompletionHandler();
+            self.stopCompletionHandler = nil;
+            break;
+        default:
+            break;
+    }
+}
+
+- (void)handleError:(nonnull NSError *)error {
+    id isFatal = error.userInfo[OpenVPNAdapterErrorFatalKey];
+    if (!([isFatal respondsToSelector:@selector(boolValue)] && [isFatal boolValue])) {
+        return;
+    }
+    if (self.startCompletionHandler) {
+        self.startCompletionHandler(error);
+        self.startCompletionHandler = nil;
+    } else {
+        [self cancelTunnelWithError:error];
+    }
+}
+
+- (OpenVPNConfiguration *)configuration {
+    if (![self.protocolConfiguration isKindOfClass:[NETunnelProviderProtocol class]]) return nil;
+    id configurationData = ((NETunnelProviderProtocol *)self.protocolConfiguration).providerConfiguration[OpenVPNTunnelProviderConfigurationKey];
+    if (![configurationData isKindOfClass:[NSData class]]) return nil;
+    id configuration = [NSKeyedUnarchiver unarchiveObjectWithData:configurationData];
+    if (![configuration isKindOfClass:[OpenVPNConfiguration class]]) return nil;
+    return configuration;
+}
+
+- (OpenVPNCredentials *)credentials {
+    if (!self.protocolConfiguration.username.length) return nil;
+    if (!self.protocolConfiguration.passwordReference) return nil;
+    
+    CFTypeRef reference;
+    NSDictionary *query = @{(id)kSecClass: (id)kSecClassGenericPassword,
+                            (id)kSecReturnData: (id)kCFBooleanTrue,
+                            (id)kSecValuePersistentRef: self.protocolConfiguration.passwordReference};
+    if (SecItemCopyMatching((__bridge CFDictionaryRef)query, &reference) != errSecSuccess) return nil;
+    
+    NSString *password = [[NSString alloc] initWithData:(__bridge NSData *)reference encoding:NSUTF8StringEncoding];
+    if (!password.length) return nil;
+    
+    OpenVPNCredentials *credentials = [[OpenVPNCredentials alloc] init];
+    credentials.username = self.protocolConfiguration.username;
+    credentials.password = password;
+    return credentials;
+}
+
+- (OpenVPNAdapter *)adapter {
+    if (!_adapter) {
+        _adapter = [[OpenVPNAdapter alloc] init];
+        _adapter.delegate = self;
+    }
+    return _adapter;
+}
+
+- (OpenVPNReachability *)reachability {
+    if (!_reachability) {
+        _reachability = [[OpenVPNReachability alloc] init];
+    }
+    return _reachability;
+}
+
+@end

--- a/OpenVPN Adapter/OpenVPNTunnelProvider.m
+++ b/OpenVPN Adapter/OpenVPNTunnelProvider.m
@@ -69,6 +69,7 @@ NSString * const OpenVPNTunnelProviderConfigurationKey = @"OpenVPNTunnelProvider
 
 - (void)stopTunnelWithReason:(NEProviderStopReason)reason completionHandler:(void (^)(void))completionHandler {
     self.stopCompletionHandler = completionHandler;
+    [self.reachability stopTracking];
     [self.adapter disconnect];
 }
 

--- a/OpenVPN Adapter/OpenVPNTunnelProvider.m
+++ b/OpenVPN Adapter/OpenVPNTunnelProvider.m
@@ -141,6 +141,22 @@ NSString * const OpenVPNTunnelProviderConfigurationKey = @"OpenVPNTunnelProvider
     return credentials;
 }
 
+- (OpenVPNConnectionInfo *)connectionInformation {
+    return self.adapter.connectionInfo;
+}
+
+- (OpenVPNInterfaceStats *)interfaceStatistics {
+    return self.adapter.interfaceStats;
+}
+
+- (OpenVPNSessionToken *)sessionToken {
+    return self.adapter.sessionToken;
+}
+
+- (OpenVPNTransportStats *)transportStatistics {
+    return self.adapter.transportStats;
+}
+
 - (OpenVPNAdapter *)adapter {
     if (!_adapter) {
         _adapter = [[OpenVPNAdapter alloc] init];

--- a/OpenVPN Adapter/Umbrella-Header.h
+++ b/OpenVPN Adapter/Umbrella-Header.h
@@ -39,3 +39,4 @@ FOUNDATION_EXPORT const unsigned char OpenVPNAdapterVersionString[];
 #import <OpenVPNAdapter/OpenVPNReachabilityStatus.h>
 #import <OpenVPNAdapter/OpenVPNReachability.h>
 #import <OpenVPNAdapter/OpenVPNTunnelProvider.h>
+#import <OpenVPNAdapter/NEVPNProtocol+OpenVPNAdapter.h>

--- a/OpenVPN Adapter/Umbrella-Header.h
+++ b/OpenVPN Adapter/Umbrella-Header.h
@@ -38,3 +38,4 @@ FOUNDATION_EXPORT const unsigned char OpenVPNAdapterVersionString[];
 #import <OpenVPNAdapter/OpenVPNPrivateKey.h>
 #import <OpenVPNAdapter/OpenVPNReachabilityStatus.h>
 #import <OpenVPNAdapter/OpenVPNReachability.h>
+#import <OpenVPNAdapter/OpenVPNTunnelProvider.h>


### PR DESCRIPTION
This PR proposes adding a `NEPacketTunnelProvider` subclass to `OpenVPNAdapter`.

In my development so far, I have been writing an iOS app and macOS app concurrently. I have found there is a lot of duplicate code in both pertaining to `OpenVPNAdapter` and I feel some of this code would belong in the library for all to use.

`OpenVPNTunnelProvider` is a subclass of `NEPacketTunnelProvider` which implements a lot of the interoperation logic between `OpenVPNAdapter` and the `NetworkExtension` frameworks.

Supplying an `OpenVPNConfiguration` to the class is as simple as setting the `openVPNConfiguration` property on `NEVPNProtocol`.

Supplying credentials is done via the `username` and `passwordReference` properties on `NEVPNProtocol `.

I feel this would be a useful addition to the framework and welcome any thoughts you may have.