### PR TITLE
Fix Reconnect Bug

### DIFF
--- a/OpenVPN Adapter/OpenVPNAdapter.h
+++ b/OpenVPN Adapter/OpenVPNAdapter.h
@@ -38,8 +38,8 @@ typedef NS_ENUM(NSInteger, OpenVPNAdapterEvent);
  @param completionHandler The completion handler to be called with a NEPacketTunnelFlow object, or nil if an error occurred.
  */
 - (void)openVPNAdapter:(OpenVPNAdapter *)openVPNAdapter
-configureTunnelWithNetworkSettings:(NEPacketTunnelNetworkSettings *)networkSettings
-                 completionHandler:(void (^)(id<OpenVPNAdapterPacketFlow> _Nullable packetFlow))completionHandler
+configureTunnelWithNetworkSettings:(nullable NEPacketTunnelNetworkSettings *)networkSettings
+                 completionHandler:(nullable void (^)(id<OpenVPNAdapterPacketFlow> _Nullable packetFlow))completionHandler
 NS_SWIFT_NAME(openVPNAdapter(_:configureTunnelWithNetworkSettings:completionHandler:));
 
 /**

--- a/OpenVPN Adapter/OpenVPNAdapter.mm
+++ b/OpenVPN Adapter/OpenVPNAdapter.mm
@@ -346,6 +346,7 @@
     _sessionName = nil;
     _packetFlowBridge = nil;
     _networkSettingsBuilder = nil;
+    [self.delegate openVPNAdapter:self configureTunnelWithNetworkSettings:nil completionHandler:nil];
 }
 
 #pragma mark -

--- a/OpenVPN Adapter/OpenVPNClient.mm
+++ b/OpenVPN Adapter/OpenVPNClient.mm
@@ -20,7 +20,6 @@ OpenVPNClient::OpenVPNClient(id<OpenVPNClientDelegate> delegate): ClientAPI::Ope
 }
 
 bool OpenVPNClient::tun_builder_new() {
-    [this->delegate resetSettings];
     return true;
 }
 

--- a/README.md
+++ b/README.md
@@ -227,15 +227,16 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
 extension PacketTunnelProvider: OpenVPNAdapterDelegate {
 
-    // OpenVPNAdapter calls this delegate method to configure a VPN tunnel.
+    // OpenVPNAdapter calls this delegate method to either configure a VPN
+    // tunnel or reset the tunnel (during a reconnect for example).
     // `completionHandler` callback requires an object conforming to `OpenVPNAdapterPacketFlow`
     // protocol if the tunnel is configured without errors. Otherwise send nil.
     // `OpenVPNAdapterPacketFlow` method signatures are similar to `NEPacketTunnelFlow` so
     // you can just extend that class to adopt `OpenVPNAdapterPacketFlow` protocol and
     // send `self.packetFlow` to `completionHandler` callback.
-    func openVPNAdapter(_ openVPNAdapter: OpenVPNAdapter, configureTunnelWithNetworkSettings networkSettings: NEPacketTunnelNetworkSettings, completionHandler: @escaping (OpenVPNAdapterPacketFlow?) -> Void) {
+    func openVPNAdapter(_ openVPNAdapter: OpenVPNAdapter, configureTunnelWithNetworkSettings networkSettings: NEPacketTunnelNetworkSettings?, completionHandler: ((OpenVPNAdapterPacketFlow?) -> Void)? = nil) {
         setTunnelNetworkSettings(settings) { (error) in
-            completionHandler(error == nil ? self.packetFlow : nil)
+            completionHandler?(error == nil ? self.packetFlow : nil)
         }
     }
 


### PR DESCRIPTION
Now here's an interesting one.

I've been experiencing a rare - but nonetheless - annoying issue where the openvpn3 library would enter a seemingly infinite loop whilst trying to resolve the remote hostname, when reconnecting after an interface change.

The fix appears to be resetting the system's packet flow object's network settings during a tunnel teardown. The apple documentation states:

> `tunnelNetworkSettings`: The network settings to use for the tunnel. **Pass nil to clear out the network settings for the current tunneling session**.

Currently this is not occurring, and I believe this means that during a reconnect, openvpn3 uses the previous tunnel to download the new network settings, which normally works, but sometimes will not, if the existing tunnel is no longer viable.

Having field tested this fix on our test devices in environments that usually result in infinite reconnect loops (poor wi-fi and cellular areas in particular), I believe this fix works and will benefit anyone using this library.

I have also removed the `-resetSettings` call from `tun_builder_new` since this is a redundant call which results in the tunnel being reset twice during a reconnect.

I look forward to your thoughts.